### PR TITLE
Fix outdated Step09 in Tutorial

### DIFF
--- a/Documentation/Doxygen/Tutorial/Step09.dox
+++ b/Documentation/Doxygen/Tutorial/Step09.dox
@@ -1,5 +1,5 @@
 /**
- 
+
 \page Step09Page MITK Tutorial - Step 9: A plug-in
 
 MITK uses a very modular concept to maximize reusability and portability. You start an application (for example mitkWorkbench, the sample application provided by MITK). An application has several bundles (or plug-ins). A bundle can be a functionality, which in turn can be a view, each of these terms specifying certain behaviour and attributes.
@@ -28,12 +28,12 @@ manifest_headers.cmake.................... Information about your plug-in
 plugin.xml ............................... BlueBerry integration
 \endverbatim
 
-If you are not familiar with Qt development, please look into 
+If you are not familiar with Qt development, please look into
 <a href="http://doc.trolltech.com/4.6/designer-manual.html">this Trolltech page describing .ui files</a> (no, forget about the please, DO it!)
 
 The C++ files implement a subclass of QmitkAbstractView. In this special case of QmitkRegionGrowing, we added the ability to set some seed points and run a region grower. If you are interested in the concrete changes necessary to turn a freshly generated QmitkRegionGrowing into an integrated one:
 
-Since an access to the StdMultiWidget is needed, manifest_headers.cmake has to be edited: 
+Since an access to the StdMultiWidget is needed, manifest_headers.cmake has to be edited:
 \verbatim
 set(Require-Plugin org.mitk.gui.qt.common org.mitk.gui.qt.stdmultiwidgeteditor)
 \endverbatim
@@ -56,10 +56,10 @@ mitk::PointSet::Pointer m_PointSet;
 QmitkPointListWidget* lstPoints;
 QmitkStdMultiWidget* m_MultiWidget;
 \endverbatim
- 
+
 QmitkRegionGrowingView.cpp
 
-CreateQtPartControl(): 
+CreateQtPartControl():
 \verbatim
 // create a QmitkPointListWidget and add it to the widget created from .ui file
 lstPoints = new QmitkPointListWidget();
@@ -71,7 +71,7 @@ m_MultiWidget = qSMWE->GetStdMultiWidget();
 
 // let the point set widget know about the multi widget (crosshair updates)
 lstPoints->SetMultiWidget( m_MultiWidget );
-      
+
 // create a new DataTreeNode containing a PointSet with some interaction
 m_PointSet = mitk::PointSet::New();
 
@@ -124,7 +124,7 @@ DoImageProcessing();
 if ( m_PointSet->GetSize() == 0 )
 {
   // no points there. Not good for region growing
-  QMessageBox::information( NULL, "Region growing functionality", 
+  QMessageBox::information( NULL, "Region growing functionality",
                                   "Please set some seed points inside the image first.\n"
                                   "(hold Shift key and click left mouse button inside the image.)"
                                 );
@@ -142,7 +142,7 @@ void QmitkRegionGrowingView::ItkImageProcessing( itk::Image< TPixel, VImageDimen
 {
   typedef itk::Image< TPixel, VImageDimension > InputImageType;
   typedef typename InputImageType::IndexType    IndexType;
-  
+
   // instantiate an ITK region growing filter, set its parameters
   typedef itk::ConnectedThresholdImageFilter<InputImageType, InputImageType> RegionGrowingFilterType;
   typename RegionGrowingFilterType::Pointer regionGrower = RegionGrowingFilterType::New();
@@ -153,12 +153,12 @@ void QmitkRegionGrowingView::ItkImageProcessing( itk::Image< TPixel, VImageDimen
   TPixel min( std::numeric_limits<TPixel>::max() );
   TPixel max( std::numeric_limits<TPixel>::min() );
   mitk::PointSet::PointsContainer* points = m_PointSet->GetPointSet()->GetPoints();
-  for ( mitk::PointSet::PointsConstIterator pointsIterator = points->Begin(); 
+  for ( mitk::PointSet::PointsConstIterator pointsIterator = points->Begin();
         pointsIterator != points->End();
-        ++pointsIterator ) 
+        ++pointsIterator )
   {
     // first test if this point is inside the image at all
-    if ( !imageGeometry->IsInside( pointsIterator.Value()) ) 
+    if ( !imageGeometry->IsInside( pointsIterator.Value()) )
     {
       continue;
     }
@@ -179,7 +179,7 @@ void QmitkRegionGrowingView::ItkImageProcessing( itk::Image< TPixel, VImageDimen
     regionGrower->AddSeed( seedIndex );
   }
 
-  std::cout << "Values between " << min << " and " << max << std::endl;
+  MITK_INFO << "Values between " << min << " and " << max;
 
   min -= 30;
   max += 30;
@@ -191,7 +191,7 @@ void QmitkRegionGrowingView::ItkImageProcessing( itk::Image< TPixel, VImageDimen
   regionGrower->Update();
 
   mitk::Image::Pointer resultImage = mitk::ImportItkImage( regionGrower->GetOutput() );
-  mitk::DataTreeNode::Pointer newNode = mitk::DataTreeNode::New();
+  mitk::DataNode::Pointer newNode = mitk::DataNode::New();
   newNode->SetData( resultImage );
 
   // set some properties
@@ -203,7 +203,7 @@ void QmitkRegionGrowingView::ItkImageProcessing( itk::Image< TPixel, VImageDimen
   newNode->SetProperty("opacity", mitk::FloatProperty::New(0.5));
 
   // add result to data tree
-  this->GetDefaultDataStorage()->Add( newNode );
+  this->GetDataStorage()->Add( newNode );
   mitk::RenderingManager::GetInstance()->RequestUpdateAll();
 }
 
@@ -211,9 +211,9 @@ void QmitkRegionGrowingView::ItkImageProcessing( itk::Image< TPixel, VImageDimen
 
 Have fun using MITK!
 
-If you meet any difficulties during your first steps, don't hesitate to ask on the MITK mailing list mitk-users@lists.sourceforge.net! 
+If you meet any difficulties during your first steps, don't hesitate to ask on the MITK mailing list mitk-users@lists.sourceforge.net!
 People there are kind and will try to help you.
 
  \ref Step08Page "[Previous step]" \ref Step10Page "[Next Step]" \ref TutorialPage "[Main tutorial page]"
- 
+
 */


### PR DESCRIPTION
This patch makes the Step09 of the tutorial compile without error. It
also removed unnecessary whitespaces and replace std::cout with
MITK_INFO
