### PR TITLE
TransferItkTransformToVtkMatrix: Init the homogeneous row of the vtkMatrix4x4

### DIFF
--- a/Core/Code/DataManagement/mitkMatrixConvert.h
+++ b/Core/Code/DataManagement/mitkMatrixConvert.h
@@ -59,7 +59,7 @@ namespace mitk
       vtkmatrix->SetElement(i, 3, itkTransform->GetOffset()[i]);
     for(i=0;i<3;++i)
       vtkmatrix->SetElement(3, i, 0.0);
-    vtkMatrix->SetElement(3, 3, 1);
+    vtkmatrix->SetElement(3, 3, 1.0);
   }
 
   template <class TTransformType1, class TTransformType2>


### PR DESCRIPTION
Also, drop the Modified() call - it's not necessary when using SetElement()

Fixes bug 15745:
http://bugs.mitk.org/show_bug.cgi?id=15745
