### PR TITLE
Rotate about the ReferenceGeometry center to reorient the normal vector

### DIFF
--- a/Core/Code/DataManagement/mitkSlicedGeometry3D.cpp
+++ b/Core/Code/DataManagement/mitkSlicedGeometry3D.cpp
@@ -811,7 +811,7 @@ mitk::SlicedGeometry3D::ExecuteOperation(Operation* operation)
       //
       // 1st Step: Reorient Normal Vector of first plane
       //
-      Point3D center = planeOp->GetPoint(); //m_ReferenceGeometry->GetCenter();
+      Point3D center = m_ReferenceGeometry->GetCenter();
       mitk::Vector3D currentNormal = planeGeometry->GetNormal();
       mitk::Vector3D newNormal;
       if (planeOp->AreAxisDefined())


### PR DESCRIPTION
MITK Bugzilla report: http://bugs.mitk.org/show_bug.cgi?id=15892
