### PR TITLE
COMP: Remove unused Node predicate in Geometry2DDataVtkMapper3D

### DIFF
--- a/Core/Code/Rendering/mitkGeometry2DDataVtkMapper3D.cpp
+++ b/Core/Code/Rendering/mitkGeometry2DDataVtkMapper3D.cpp
@@ -388,7 +388,6 @@ namespace mitk
       LayerSortedActorList layerSortedActors;
 
       // Traverse the data tree to find nodes resliced by ImageMapperGL2D
-      mitk::NodePredicateOr::Pointer p = mitk::NodePredicateOr::New();
       //use a predicate to get all data nodes which are "images" or inherit from mitk::Image
       mitk::TNodePredicateDataType< mitk::Image >::Pointer predicateAllImages = mitk::TNodePredicateDataType< mitk::Image >::New();
       mitk::DataStorage::SetOfObjects::ConstPointer all = m_DataStorage->GetSubset(predicateAllImages);


### PR DESCRIPTION
Bugzilla report: http://bugs.mitk.org/show_bug.cgi?id=15894
