### PR TITLE
- The number of time steps between masks and images can now be different

### DIFF
--- a/Modules/ImageStatistics/mitkImageStatisticsCalculator.cpp
+++ b/Modules/ImageStatistics/mitkImageStatisticsCalculator.cpp
@@ -132,11 +132,6 @@ void ImageStatisticsCalculator::SetImageMask( const mitk::Image *imageMask )
     itkExceptionMacro( << "Image needs to be set first!" );
   }
 
-  if ( m_Image->GetTimeSteps() != imageMask->GetTimeSteps() )
-  {
-    itkExceptionMacro( << "Image and image mask need to have equal number of time steps!" );
-  }
-
   if ( m_ImageMask != imageMask )
   {
     m_ImageMask = imageMask;
@@ -572,21 +567,27 @@ void ImageStatisticsCalculator::ExtractImageAndMask( unsigned int timeStep )
     {
       if ( m_ImageMask.IsNotNull() && (m_ImageMask->GetReferenceCount() > 1) )
       {
-        if ( timeStep < m_ImageMask->GetTimeSteps() )
+        if ( timeStep >= m_ImageMask->GetTimeSteps() )
         {
-          ImageTimeSelector::Pointer maskedImageTimeSelector = ImageTimeSelector::New();
-          maskedImageTimeSelector->SetInput( m_ImageMask );
-          maskedImageTimeSelector->SetTimeNr( timeStep );
-          maskedImageTimeSelector->UpdateLargestPossibleRegion();
-          mitk::Image *timeSliceMaskedImage = maskedImageTimeSelector->GetOutput();
+          // Use the last mask time step in case the current time step is bigger than the total
+          // number of mask time steps.
+          // It makes more sense setting this to the last mask time step than to 0.
+          // For instance if you have a mask with 2 time steps and an image with 5:
+          // If time step 0 is selected, the mask will use time step 0.
+          // If time step 1 is selected, the mask will use time step 1.
+          // If time step 2+ is selected, the mask will use time step 1.
+          // If you have a mask with only one time step instead, this will always default to 0.
+          timeStep = m_ImageMask->GetTimeSteps() - 1;
+        }
 
-          m_InternalImage = timeSliceImage;
-          CastToItkImage( timeSliceMaskedImage, m_InternalImageMask3D );
-        }
-        else
-        {
-          throw std::runtime_error( "Error: image mask has not enough time steps!" );
-        }
+        ImageTimeSelector::Pointer maskedImageTimeSelector = ImageTimeSelector::New();
+        maskedImageTimeSelector->SetInput( m_ImageMask );
+        maskedImageTimeSelector->SetTimeNr( timeStep );
+        maskedImageTimeSelector->UpdateLargestPossibleRegion();
+        mitk::Image *timeSliceMaskedImage = maskedImageTimeSelector->GetOutput();
+
+        m_InternalImage = timeSliceImage;
+        CastToItkImage( timeSliceMaskedImage, m_InternalImageMask3D );
       }
       else
       {
@@ -1071,7 +1072,7 @@ void ImageStatisticsCalculator::InternalCalculateStatisticsMasked(
   else
   {
     histogramContainer->push_back( HistogramType::ConstPointer( m_EmptyHistogram ) );
-    statisticsContainer->push_back( Statistics() );;
+    statisticsContainer->push_back( Statistics() );
   }
 }
 

--- a/Modules/ImageStatistics/mitkImageStatisticsCalculator.h
+++ b/Modules/ImageStatistics/mitkImageStatisticsCalculator.h
@@ -73,6 +73,11 @@ public:
 
   struct Statistics
   {
+    Statistics()
+    {
+      Reset();
+    }
+
     int Label;
     unsigned int N;
     double Min;

--- a/Plugins/org.mitk.gui.qt.measurementtoolbox/documentation/UserManual/QmitkImageStatistics.dox
+++ b/Plugins/org.mitk.gui.qt.measurementtoolbox/documentation/UserManual/QmitkImageStatistics.dox
@@ -28,7 +28,7 @@ This view provides an easy interface to quickly compute some features of a whole
 
 \section QmitkImageStatisticsUserManualUsage Usage
 
-After selection of an image or a binary mask of an image in the datamanager, the Image Statistics view shows some statistical information. If a mask is selected, the name of the mask and the name of the image, to which the mask is applied, are shown at the top.
+After selection of an image or a binary mask of an image in the datamanager, the Image Statistics view shows some statistical information. If a mask is selected, the name of the mask and the name of the image, to which the mask is applied, are shown at the top. For time data the current time step is used for the selected mask and the selected image. If the total number of time steps on the selected mask is less than the current time step, the last time step of the mask is used. If a mask is selected, its used time step will be displayed next to its name like this: (t=0).
 
 Check "Ignore zero-valued voxels" to hide voxels with grayvalue zero.
 

--- a/Plugins/org.mitk.gui.qt.measurementtoolbox/src/internal/QmitkImageStatisticsView.cpp
+++ b/Plugins/org.mitk.gui.qt.measurementtoolbox/src/internal/QmitkImageStatisticsView.cpp
@@ -42,6 +42,7 @@ QmitkImageStatisticsView::QmitkImageStatisticsView(QObject* /*parent*/, const ch
   m_ImageObserverTag( -1 ),
   m_ImageMaskObserverTag( -1 ),
   m_PlanarFigureObserverTag( -1 ),
+  m_TimeObserverTag( -1 ),
   m_CurrentStatisticsValid( false ),
   m_StatisticsUpdatePending( false ),
   m_DataNodeSelectionChanged ( false ),
@@ -91,6 +92,74 @@ void QmitkImageStatisticsView::CreateConnections()
     connect( (QObject*) this->m_Controls->m_StatisticsTable, SIGNAL(cellDoubleClicked(int,int)),this, SLOT( JumpToCoordinates(int,int)) );
     connect( (QObject*) (this->m_Controls->m_barRadioButton), SIGNAL(clicked()), (QObject*) (this->m_Controls->m_JSHistogram), SLOT(OnBarRadioButtonSelected()));
     connect( (QObject*) (this->m_Controls->m_lineRadioButton), SIGNAL(clicked()), (QObject*) (this->m_Controls->m_JSHistogram), SLOT(OnLineRadioButtonSelected()));
+  }
+
+  mitk::IRenderWindowPart* renderWindow = GetRenderWindowPart();
+
+  if (renderWindow)
+  {
+    itk::ReceptorMemberCommand<QmitkImageStatisticsView>::Pointer cmdTimeEvent =
+      itk::ReceptorMemberCommand<QmitkImageStatisticsView>::New();
+    cmdTimeEvent->SetCallbackFunction(this, &QmitkImageStatisticsView::OnTimeChanged);
+
+    // It is sufficient to add the observer to the axial render window since the GeometryTimeEvent
+    // is always triggered by all views.
+    m_TimeObserverTag = renderWindow->GetQmitkRenderWindow("axial")->
+      GetSliceNavigationController()->
+      AddObserver(mitk::SliceNavigationController::GeometryTimeEvent(NULL, 0), cmdTimeEvent);
+  }
+}
+
+void QmitkImageStatisticsView::PartClosed( berry::IWorkbenchPartReference::Pointer )
+{
+  // The slice navigation controller observer is removed here instead of in the destructor.
+  // If it was called in the destructor, the application would freeze because the view's
+  // destructor gets called after the render windows have been destructed.
+  if ( m_TimeObserverTag != NULL )
+  {
+    mitk::IRenderWindowPart* renderWindow = GetRenderWindowPart();
+
+    if (renderWindow)
+    {
+      renderWindow->GetQmitkRenderWindow("axial")->GetSliceNavigationController()->
+        RemoveObserver( m_TimeObserverTag );
+    }
+  }
+}
+
+void QmitkImageStatisticsView::OnTimeChanged(const itk::EventObject&)
+{
+  if (m_SelectedImage != NULL && !this->m_StatisticsUpdatePending)
+  {
+    while( this->m_CalculationThread->isRunning()) // wait until thread has finished
+    {
+      itksys::SystemTools::Delay(100);
+    }
+
+    if(this->m_SelectedImage != NULL)
+    {
+      this->m_SelectedImage->RemoveObserver( this->m_ImageObserverTag);
+      this->m_SelectedImage = NULL;
+    }
+
+    if(this->m_SelectedImageMask != NULL)
+    {
+      this->m_SelectedImageMask->RemoveObserver( this->m_ImageMaskObserverTag);
+      this->m_SelectedImageMask = NULL;
+    }
+
+    if(this->m_SelectedPlanarFigure != NULL)
+    {
+      this->m_SelectedPlanarFigure->RemoveObserver( this->m_PlanarFigureObserverTag);
+      this->m_SelectedPlanarFigure = NULL;
+    }
+
+    m_Controls->m_ErrorMessageLabel->setText("");
+    m_Controls->m_ErrorMessageLabel->hide();
+    this->InvalidateStatisticsTableView();
+    m_Controls->m_StatisticsWidgetStack->setCurrentIndex(0);
+
+    emit StatisticsUpdate();
   }
 }
 
@@ -434,6 +503,24 @@ void QmitkImageStatisticsView::UpdateStatistics()
     if(m_SelectedImage->GetDimension() <= 3 && timeStep > m_SelectedImage->GetDimension(3)-1)
     {
       timeStep = m_SelectedImage->GetDimension(3)-1;
+    }
+
+    // Add the used mask time step to the mask label so the user knows which mask time step was used
+    // if the image time step is bigger than the total number of mask time steps (see
+    // ImageStatisticsCalculator::ExtractImageAndMask)
+    if (m_SelectedImageMask != NULL)
+    {
+      unsigned int maskTimeStep = timeStep;
+
+      if (maskTimeStep >= m_SelectedImageMask->GetTimeSteps())
+      {
+        maskTimeStep = m_SelectedImageMask->GetTimeSteps() - 1;
+      }
+
+      m_Controls->m_SelectedMaskLabel->setText(m_Controls->m_SelectedMaskLabel->text() +
+                                               QString(" (t=") +
+                                               QString::number(maskTimeStep) +
+                                               QString(")"));
     }
 
     //// initialize thread and trigger it

--- a/Plugins/org.mitk.gui.qt.measurementtoolbox/src/internal/QmitkImageStatisticsView.h
+++ b/Plugins/org.mitk.gui.qt.measurementtoolbox/src/internal/QmitkImageStatisticsView.h
@@ -23,6 +23,7 @@ See LICENSE.txt or http://www.mitk.org for details.
 #include <QmitkAbstractView.h>
 #include "QmitkStepperAdapter.h"
 #include "QmitkImageStatisticsCalculationThread.h"
+#include <berryIPartListener.h>
 
 // mitk includes
 #include "mitkImageStatisticsCalculator.h"
@@ -37,7 +38,7 @@ gui accessable during calculation.
 
 \ingroup Plugins/org.mitk.gui.qt.measurementtoolbox
 */
-class QmitkImageStatisticsView : public QmitkAbstractView, public mitk::ILifecycleAwarePart
+class QmitkImageStatisticsView : public QmitkAbstractView, public mitk::ILifecycleAwarePart, public berry::IPartListener
 {
   Q_OBJECT
 
@@ -135,6 +136,15 @@ protected:
 
   void NodeRemoved(const mitk::DataNode *node);
 
+  /** \brief Is called right before the view closes (before the destructor) */
+  virtual void PartClosed( berry::IWorkbenchPartReference::Pointer );
+  /** \brief Is called from the image navigator once the time step has changed */
+  void OnTimeChanged( const itk::EventObject& );
+  /** \brief Required for berry::IPartListener */
+  virtual const char* GetClassName() const { return "QmitkImageStatisticsView"; }
+  /** \brief Required for berry::IPartListener */
+  virtual Events::Types GetPartEventTypes() const { return Events::CLOSED; }
+
   // member variables
   Ui::QmitkImageStatisticsViewControls *m_Controls;
   QmitkImageStatisticsCalculationThread* m_CalculationThread;
@@ -152,6 +162,7 @@ protected:
   long m_ImageObserverTag;
   long m_ImageMaskObserverTag;
   long m_PlanarFigureObserverTag;
+  long m_TimeObserverTag;
 
   SelectedDataNodeVectorType m_SelectedDataNodes;
 


### PR DESCRIPTION
- If the mask does not have the selected time step, its last time step is used instead
- The used mask time step is displayed in the mask label
- The statistics are now updated when the time step changes
- If the mask is empty, the displayed statistics values are set to 0 (was displaying uninitialized variable values)
