### PR TITLE
Flag to disable repositioning/rescaling displayed region when a render window is resized

### DIFF
--- a/Core/Code/Rendering/mitkBaseRenderer.cpp
+++ b/Core/Code/Rendering/mitkBaseRenderer.cpp
@@ -111,7 +111,7 @@ mitk::BaseRenderer::BaseRenderer(const char* name, vtkRenderWindow * renWin, mit
     m_RenderWindow(NULL), m_VtkRenderer(NULL), m_MapperID(defaultMapper), m_DataStorage(NULL), m_RenderingManager(rm), m_LastUpdateTime(0), m_CameraController(
         NULL), m_SliceNavigationController(NULL), m_CameraRotationController(NULL), /*m_Size(),*/
     m_Focused(false), m_WorldGeometry(NULL), m_WorldTimeGeometry(NULL), m_CurrentWorldGeometry(NULL), m_CurrentWorldGeometry2D(NULL), m_DisplayGeometry(
-        NULL), m_Slice(0), m_TimeStep(), m_CurrentWorldGeometry2DUpdateTime(), m_DisplayGeometryUpdateTime(), m_TimeStepUpdateTime(), m_WorldGeometryData(
+        NULL), m_Slice(0), m_TimeStep(), m_CurrentWorldGeometry2DUpdateTime(), m_DisplayGeometryUpdateTime(), m_TimeStepUpdateTime(), m_KeepDisplayedRegion(true), m_WorldGeometryData(
         NULL), m_DisplayGeometryData(NULL), m_CurrentWorldGeometry2DData(NULL), m_WorldGeometryNode(NULL), m_DisplayGeometryNode(NULL), m_CurrentWorldGeometry2DNode(
         NULL), m_DisplayGeometryTransformTime(0), m_CurrentWorldGeometry2DTransformTime(0), m_Name(name), /*m_Bounds(),*/m_EmptyWorldGeometry(
         true), m_DepthPeelingEnabled(true), m_MaxNumberOfPeels(100), m_NumberOfVisibleLODEnabledMappers(0)
@@ -316,7 +316,7 @@ void mitk::BaseRenderer::Resize(int w, int h)
   if (m_CameraController)
     m_CameraController->Resize(w, h); //(formerly problematic on windows: vtkSizeBug)
 
-  GetDisplayGeometry()->SetSizeInDisplayUnits(w, h);
+  GetDisplayGeometry()->SetSizeInDisplayUnits(w, h, m_KeepDisplayedRegion);
 }
 
 void mitk::BaseRenderer::InitRenderer(vtkRenderWindow* renderwindow)

--- a/Core/Code/Rendering/mitkBaseRenderer.h
+++ b/Core/Code/Rendering/mitkBaseRenderer.h
@@ -383,6 +383,13 @@ namespace mitk
     itkGetMacro(EmptyWorldGeometry, bool)
 
     //##Documentation
+    //## @brief Tells if the displayed region is shifted and rescaled if the render window is resized.
+    itkGetMacro(KeepDisplayedRegion, bool)
+    //##Documentation
+    //## @brief Tells if the displayed region should be shifted and rescaled if the render window is resized.
+    itkSetMacro(KeepDisplayedRegion, bool)
+
+    //##Documentation
     //## @brief Mouse event dispatchers
     //## @note for internal use only. preliminary.
     virtual void MousePressEvent(MouseEvent*);
@@ -578,6 +585,10 @@ namespace mitk
     //##Documentation
     //## @brief Helper class which establishes connection between Interactors and Dispatcher via a common DataStorage.
     BindDispatcherInteractor* m_BindDispatcherInteractor;
+
+    //##Documentation
+    //## @brief Tells if the displayed region should be shifted or rescaled if the render window is resized.
+    bool m_KeepDisplayedRegion;
 
   protected:
     virtual void PrintSelf(std::ostream& os, itk::Indent indent) const;


### PR DESCRIPTION
Proposed fix for Bug 16862
