### PR TITLE
Test framework to enforce atomic state transitions

### DIFF
--- a/Modules/Qmitk/Testing/CMakeLists.txt
+++ b/Modules/Qmitk/Testing/CMakeLists.txt
@@ -1,1 +1,8 @@
-MITK_CREATE_MODULE_TESTS()
+set(QT_USE_QTTEST 1)
+include(${QT_USE_FILE})
+
+MITK_CREATE_MODULE_TESTS(LABELS Qmitk)
+
+mitkAddCustomModuleTest(Qmitk-StdMultiWidgetTest QmitkStdMultiWidgetTest ${NIFTK_DATA_DIR}/Input/volunteers/16856/16856-002-1.img)
+
+#target_link_libraries(QmitkStdMultiWidgetTestDriver ${QT_QTTEST_LIBRARY})

--- a/Modules/Qmitk/Testing/QmitkStdMultiWidgetState.h
+++ b/Modules/Qmitk/Testing/QmitkStdMultiWidgetState.h
@@ -1,0 +1,97 @@
+/*=============================================================================
+
+  NifTK: A software platform for medical image computing.
+
+  Copyright (c) University College London (UCL). All rights reserved.
+
+  This software is distributed WITHOUT ANY WARRANTY; without even
+  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+  PURPOSE.
+
+  See LICENSE.txt in the top level directory for details.
+
+=============================================================================*/
+
+#ifndef __QmitkStdMultiWidgetState_h
+#define __QmitkStdMultiWidgetState_h
+
+#include <QmitkStdMultiWidget.h>
+
+static bool EqualsWithTolerance(const mitk::Vector2D& cursorPosition1, const mitk::Vector2D& cursorPosition2, double tolerance = 0.001)
+{
+  return std::abs(cursorPosition1[0] - cursorPosition2[0]) < tolerance
+      && std::abs(cursorPosition1[1] - cursorPosition2[1]) < tolerance;
+}
+
+static bool EqualsWithTolerance(const std::vector<mitk::Vector2D>& cursorPositions1, const std::vector<mitk::Vector2D>& cursorPositions2, double tolerance = 0.001)
+{
+  for (int i = 0; i < 3; ++i)
+  {
+    if (!::EqualsWithTolerance(cursorPositions1[i], cursorPositions2[i], tolerance))
+    {
+      return false;
+    }
+  }
+  return true;
+}
+
+class QmitkStdMultiWidgetState : public itk::Object
+{
+public:
+
+  mitkClassMacro(QmitkStdMultiWidgetState, itk::Object);
+  mitkNewMacro1Param(QmitkStdMultiWidgetState, const QmitkStdMultiWidget*);
+  mitkNewMacro1Param(QmitkStdMultiWidgetState, Self::Pointer);
+
+  // TODO: Put getters and setters here.
+
+  bool operator==(const QmitkStdMultiWidgetState& otherState) const
+  {
+    // TODO
+    return 1;
+  }
+
+  inline bool operator!=(const QmitkStdMultiWidgetState& otherState) const
+  {
+    return !(*this == otherState);
+  }
+
+  void PrintDifference(QmitkStdMultiWidgetState::Pointer otherState, std::ostream & os = std::cout, itk::Indent indent = 0) const
+  {
+    // TODO
+  }
+
+protected:
+
+  /// \brief Constructs a QmitkStdMultiWidgetState object that stores the current state of the specified viewer.
+  QmitkStdMultiWidgetState(const QmitkStdMultiWidget* viewer)
+  : itk::Object()
+  // TODO
+  {
+  }
+
+  /// \brief Constructs a QmitkStdMultiWidgetState object as a copy of another state object.
+  QmitkStdMultiWidgetState(Self::Pointer otherState)
+  : itk::Object()
+  // TODO
+  {
+  }
+
+  /// \brief Destructs a QmitkStdMultiWidgetState object.
+  virtual ~QmitkStdMultiWidgetState()
+  {
+  }
+
+  /// \brief Prints the collected signals to the given stream or to the standard output if no stream is given.
+  virtual void PrintSelf(std::ostream & os, itk::Indent indent) const
+  {
+    // TODO
+  }
+
+private:
+
+  // TODO Declare members here.
+
+};
+
+#endif

--- a/Modules/Qmitk/Testing/QmitkStdMultiWidgetTest.cpp
+++ b/Modules/Qmitk/Testing/QmitkStdMultiWidgetTest.cpp
@@ -1,0 +1,394 @@
+/*=============================================================================
+
+  NifTK: A software platform for medical image computing.
+
+  Copyright (c) University College London (UCL). All rights reserved.
+
+  This software is distributed WITHOUT ANY WARRANTY; without even
+  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+  PURPOSE.
+
+  See LICENSE.txt in the top level directory for details.
+
+=============================================================================*/
+
+#include "QmitkStdMultiWidgetTest.h"
+
+#include <QApplication>
+#include <QSignalSpy>
+#include <QTest>
+#include <QTextStream>
+
+#include <mitkGlobalInteraction.h>
+#include <mitkIOUtil.h>
+#include <mitkStandaloneDataStorage.h>
+#include <mitkTestingMacros.h>
+
+#include <QmitkRenderingManagerFactory.h>
+#include <QmitkApplicationCursor.h>
+
+#include <QmitkStdMultiWidget.h>
+
+#include <mitkItkSignalCollector.cpp>
+#include <mitkQtSignalCollector.cpp>
+#include <QmitkStdMultiWidgetState.h>
+
+
+class QmitkStdMultiWidgetTestClassPrivate
+{
+public:
+  QmitkStdMultiWidgetTestClassPrivate();
+
+  std::string FileName;
+  mitk::DataStorage::Pointer DataStorage;
+  mitk::RenderingManager::Pointer RenderingManager;
+
+  mitk::DataNode::Pointer ImageNode;
+  mitk::Image* Image;
+
+  QmitkStdMultiWidget* Viewer;
+
+  QmitkStdMultiWidgetTestClass::ViewerStateTester::Pointer StateTester;
+
+  bool InteractiveMode;
+
+  mitk::Vector3D SpacingsInWorld;
+
+  QmitkRenderWindow* AxialWindow;
+  QmitkRenderWindow* SagittalWindow;
+  QmitkRenderWindow* CoronalWindow;
+  QmitkRenderWindow* _3DWindow;
+  
+  mitk::SliceNavigationController* AxialSnc;
+  mitk::SliceNavigationController* SagittalSnc;
+  mitk::SliceNavigationController* CoronalSnc;
+
+  mitk::DisplayGeometry* AxialDisplayGeometry;
+  mitk::DisplayGeometry* SagittalDisplayGeometry;
+  mitk::DisplayGeometry* CoronalDisplayGeometry;
+
+  mitk::FocusEvent FocusEvent;
+  mitk::SliceNavigationController::GeometrySliceEvent GeometrySliceEvent;
+  itk::ModifiedEvent ModifiedEvent;
+};
+
+
+// --------------------------------------------------------------------------
+QmitkStdMultiWidgetTestClassPrivate::QmitkStdMultiWidgetTestClassPrivate()
+: ImageNode(0)
+, Image(0)
+, Viewer(0)
+, InteractiveMode(false)
+, GeometrySliceEvent(NULL, 0)
+{
+  this->SpacingsInWorld.Fill(1.0);
+}
+
+// --------------------------------------------------------------------------
+QmitkStdMultiWidgetTestClass::QmitkStdMultiWidgetTestClass()
+: QObject()
+, d_ptr(new QmitkStdMultiWidgetTestClassPrivate())
+{
+}
+
+
+// --------------------------------------------------------------------------
+QmitkStdMultiWidgetTestClass::~QmitkStdMultiWidgetTestClass()
+{
+}
+
+
+// --------------------------------------------------------------------------
+std::string QmitkStdMultiWidgetTestClass::GetFileName() const
+{
+  Q_D(const QmitkStdMultiWidgetTestClass);
+  return d->FileName;
+}
+
+
+// --------------------------------------------------------------------------
+void QmitkStdMultiWidgetTestClass::SetFileName(const std::string& fileName)
+{
+  Q_D(QmitkStdMultiWidgetTestClass);
+  d->FileName = fileName;
+}
+
+
+// --------------------------------------------------------------------------
+bool QmitkStdMultiWidgetTestClass::GetInteractiveMode() const
+{
+  Q_D(const QmitkStdMultiWidgetTestClass);
+  return d->InteractiveMode;
+}
+
+
+// --------------------------------------------------------------------------
+void QmitkStdMultiWidgetTestClass::SetInteractiveMode(bool interactiveMode)
+{
+  Q_D(QmitkStdMultiWidgetTestClass);
+  d->InteractiveMode = interactiveMode;
+}
+
+
+// --------------------------------------------------------------------------
+QPoint QmitkStdMultiWidgetTestClass::GetPointAtCursorPosition(QmitkRenderWindow *renderWindow, const mitk::Vector2D& cursorPosition)
+{
+  QRect rect = renderWindow->rect();
+  double x = cursorPosition[0] * rect.width();
+  double y = (1.0 - cursorPosition[1]) * rect.height();
+  return QPoint(x, y);
+}
+
+
+// --------------------------------------------------------------------------
+mitk::Vector2D QmitkStdMultiWidgetTestClass::GetCursorPositionAtPoint(QmitkRenderWindow *renderWindow, const QPoint& point)
+{
+  QRect rect = renderWindow->rect();
+  mitk::Vector2D cursorPosition;
+  cursorPosition[0] = double(point.x()) / rect.width();
+  cursorPosition[1] = 1.0 - double(point.y()) / rect.height();
+  return cursorPosition;
+}
+
+
+// --------------------------------------------------------------------------
+bool QmitkStdMultiWidgetTestClass::Equals(const mitk::Point3D& selectedPosition1, const mitk::Point3D& selectedPosition2)
+{
+  Q_D(QmitkStdMultiWidgetTestClass);
+
+  for (int i = 0; i < 3; ++i)
+  {
+    double tolerance = d->SpacingsInWorld[i] / 2.0;
+    if (std::abs(selectedPosition1[i] - selectedPosition2[i]) > tolerance)
+    {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+
+// --------------------------------------------------------------------------
+bool QmitkStdMultiWidgetTestClass::Equals(const mitk::Vector2D& cursorPosition1, const mitk::Vector2D& cursorPosition2, double tolerance)
+{
+  return std::abs(cursorPosition1[0] - cursorPosition2[0]) <= tolerance && std::abs(cursorPosition1[1] - cursorPosition2[1]) <= tolerance;
+}
+
+
+// --------------------------------------------------------------------------
+bool QmitkStdMultiWidgetTestClass::Equals(const std::vector<mitk::Vector2D>& cursorPositions1, const std::vector<mitk::Vector2D>& cursorPositions2, double tolerance)
+{
+  return cursorPositions1.size() == std::size_t(3)
+      && cursorPositions2.size() == std::size_t(3)
+      && Self::Equals(cursorPositions1[0], cursorPositions2[0], tolerance)
+      && Self::Equals(cursorPositions1[1], cursorPositions2[1], tolerance)
+      && Self::Equals(cursorPositions1[2], cursorPositions2[2], tolerance);
+}
+
+
+// --------------------------------------------------------------------------
+void QmitkStdMultiWidgetTestClass::initTestCase()
+{
+  Q_D(QmitkStdMultiWidgetTestClass);
+
+  mitk::GlobalInteraction* globalInteraction =  mitk::GlobalInteraction::GetInstance();
+  globalInteraction->Initialize("global");
+
+  /// Create and register RenderingManagerFactory for this platform.
+  static QmitkRenderingManagerFactory qmitkRenderingManagerFactory;
+  Q_UNUSED(qmitkRenderingManagerFactory);
+
+  /// Create one instance
+  static QmitkApplicationCursor globalQmitkApplicationCursor;
+  Q_UNUSED(globalQmitkApplicationCursor);
+
+  d->DataStorage = mitk::StandaloneDataStorage::New();
+
+  d->RenderingManager = mitk::RenderingManager::GetInstance();
+  d->RenderingManager->SetDataStorage(d->DataStorage);
+
+  /// Disable VTK warnings. For some reason, they appear using these tests, but
+  /// not with the real application. We simply suppress them here.
+  vtkObject::GlobalWarningDisplayOff();
+
+  std::vector<std::string> files;
+  files.push_back(d->FileName);
+
+  mitk::IOUtil::LoadFiles(files, *(d->DataStorage.GetPointer()));
+  mitk::DataStorage::SetOfObjects::ConstPointer allImages = d->DataStorage->GetAll();
+  MITK_TEST_CONDITION_REQUIRED(mitk::Equal(allImages->size(), 1), ".. Test image loaded.");
+
+  d->ImageNode = (*allImages)[0];
+  d->ImageNode->SetVisibility(true);
+
+  d->Image = dynamic_cast<mitk::Image*>(d->ImageNode->GetData());
+  
+  // TODO
+  // Fill d->SpacingsInWorld with correct values. Expected axis order is Sagittal, Coronal, Axial, i.e. in world coordinate order.  
+}
+
+
+// --------------------------------------------------------------------------
+void QmitkStdMultiWidgetTestClass::cleanupTestCase()
+{
+}
+
+
+// --------------------------------------------------------------------------
+void QmitkStdMultiWidgetTestClass::init()
+{
+  Q_D(QmitkStdMultiWidgetTestClass);
+
+  d->Viewer = new QmitkStdMultiWidget(0, 0, d->RenderingManager);
+  d->Viewer->SetDataStorage(d->DataStorage);
+  d->Viewer->setObjectName(tr("QmitkStdMultiWidget"));
+
+  d->Viewer->resize(1024, 1024);
+  d->Viewer->show();
+
+  QTest::qWaitForWindowShown(d->Viewer);
+
+  d->AxialWindow = d->Viewer->GetRenderWindow1();
+  d->SagittalWindow = d->Viewer->GetRenderWindow2();
+  d->CoronalWindow = d->Viewer->GetRenderWindow3();
+  d->_3DWindow = d->Viewer->GetRenderWindow4();
+
+  d->ImageNode->SetVisibility(true);
+  d->ImageNode->SetVisibility(true, d->AxialWindow->GetRenderer());
+  d->ImageNode->SetVisibility(true, d->SagittalWindow->GetRenderer());
+  d->ImageNode->SetVisibility(true, d->CoronalWindow->GetRenderer());
+  d->ImageNode->SetVisibility(true, d->_3DWindow->GetRenderer());
+  
+  d->RenderingManager->RequestUpdateAll();
+
+  /// Create a state tester that works for all of the test functions.
+
+  mitk::FocusManager* focusManager = mitk::GlobalInteraction::GetInstance()->GetFocusManager();
+  d->AxialSnc = d->AxialWindow->GetSliceNavigationController();
+  d->SagittalSnc = d->SagittalWindow->GetSliceNavigationController();
+  d->CoronalSnc = d->CoronalWindow->GetSliceNavigationController();
+  d->AxialDisplayGeometry = d->AxialWindow->GetRenderer()->GetDisplayGeometry();
+  d->SagittalDisplayGeometry = d->SagittalWindow->GetRenderer()->GetDisplayGeometry();
+  d->CoronalDisplayGeometry = d->CoronalWindow->GetRenderer()->GetDisplayGeometry();
+
+  d->StateTester = ViewerStateTester::New(d->Viewer);
+
+  d->StateTester->Connect(focusManager, d->FocusEvent);
+  d->StateTester->Connect(d->AxialSnc, d->GeometrySliceEvent);
+  d->StateTester->Connect(d->SagittalSnc, d->GeometrySliceEvent);
+  d->StateTester->Connect(d->CoronalSnc, d->GeometrySliceEvent);
+  d->StateTester->Connect(d->AxialDisplayGeometry, d->ModifiedEvent);
+  d->StateTester->Connect(d->SagittalDisplayGeometry, d->ModifiedEvent);
+  d->StateTester->Connect(d->CoronalDisplayGeometry, d->ModifiedEvent);
+}
+
+
+// --------------------------------------------------------------------------
+void QmitkStdMultiWidgetTestClass::cleanup()
+{
+  Q_D(QmitkStdMultiWidgetTestClass);
+
+  /// Release the pointer so that the desctructor is be called.
+  d->StateTester = 0;
+
+  if (d->InteractiveMode)
+  {
+    QEventLoop loop;
+    loop.connect(d->Viewer, SIGNAL(destroyed()), SLOT(quit()));
+    loop.exec();
+  }
+
+  delete d->Viewer;
+  d->Viewer = 0;
+}
+
+
+// --------------------------------------------------------------------------
+void QmitkStdMultiWidgetTestClass::testViewer()
+{
+  Q_D(QmitkStdMultiWidgetTestClass);
+
+  /// Tests if the viewer has been successfully created.
+  QVERIFY(d->Viewer);
+}
+
+
+// --------------------------------------------------------------------------
+void QmitkStdMultiWidgetTestClass::testResize()
+{
+  Q_D(QmitkStdMultiWidgetTestClass);
+
+  ViewerState::Pointer expectedState = ViewerState::New(d->Viewer);
+  
+  // TODO Set the expected state.
+  
+  // d->StateTester->SetExpectedState(expectedState);
+  
+  d->Viewer->resize(800, 800);
+
+  QCOMPARE(d->StateTester->GetItkSignals(d->AxialSnc).size(), std::size_t(0));
+  QCOMPARE(d->StateTester->GetItkSignals(d->GeometrySliceEvent).size(), std::size_t(0));
+  QCOMPARE(d->StateTester->GetItkSignals(d->AxialDisplayGeometry, d->ModifiedEvent).size(), std::size_t(1));
+  QCOMPARE(d->StateTester->GetItkSignals(d->SagittalDisplayGeometry, d->ModifiedEvent).size(), std::size_t(1));
+  QCOMPARE(d->StateTester->GetItkSignals(d->CoronalDisplayGeometry, d->ModifiedEvent).size(), std::size_t(1));
+  QCOMPARE(d->StateTester->GetItkSignals().size(), std::size_t(3));
+  QCOMPARE(d->StateTester->GetQtSignals().size(), std::size_t(1));
+
+  d->StateTester->Clear();
+  
+  // Test other public functions or interactions.
+
+}
+
+
+// --------------------------------------------------------------------------
+static void ShiftArgs(int& argc, char* argv[], int steps = 1)
+{
+  /// We exploit that there must be a NULL pointer after the arguments.
+  /// (Guaranteed by the standard.)
+  int i = 1;
+  do
+  {
+    argv[i] = argv[i + steps];
+    ++i;
+  }
+  while (argv[i - 1]);
+  argc -= steps;
+}
+
+
+// --------------------------------------------------------------------------
+int QmitkStdMultiWidgetTest(int argc, char* argv[])
+{
+  QApplication app(argc, argv);
+  Q_UNUSED(app);
+
+  QmitkStdMultiWidgetTestClass test;
+
+  std::string interactiveModeOption("-i");
+  for (int i = 1; i < argc; ++i)
+  {
+    if (std::string(argv[i]) == interactiveModeOption)
+    {
+      test.SetInteractiveMode(true);
+      ::ShiftArgs(argc, argv);
+      break;
+    }
+  }
+
+  if (argc < 2)
+  {
+    MITK_INFO << "Missing argument. No image file given.";
+    return 1;
+  }
+
+  test.SetFileName(argv[1]);
+  ::ShiftArgs(argc, argv);
+
+  /// We used the arguments to initialise the test. No arguments is passed
+  /// to the Qt test, so that all the test functions are executed.
+//  argc = 1;
+//  argv[1] = NULL;
+  return QTest::qExec(&test, argc, argv);
+}

--- a/Modules/Qmitk/Testing/QmitkStdMultiWidgetTest.h
+++ b/Modules/Qmitk/Testing/QmitkStdMultiWidgetTest.h
@@ -1,0 +1,119 @@
+/*=============================================================================
+
+  NifTK: A software platform for medical image computing.
+
+  Copyright (c) University College London (UCL). All rights reserved.
+
+  This software is distributed WITHOUT ANY WARRANTY; without even
+  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+  PURPOSE.
+
+  See LICENSE.txt in the top level directory for details.
+
+=============================================================================*/
+
+#ifndef __QmitkStdMultiWidgetTest_h
+#define __QmitkStdMultiWidgetTest_h
+
+#include <QObject>
+
+#include <mitkAtomicStateTransitionTester.cpp>
+
+#include <QmitkStdMultiWidgetState.h>
+
+#include <vector>
+
+class QmitkStdMultiWidgetTestClassPrivate;
+
+class QmitkStdMultiWidget;
+
+namespace mitk
+{
+class DataNode;
+}
+
+class QmitkRenderWindow;
+
+class QmitkStdMultiWidgetTestClass: public QObject
+{
+  Q_OBJECT
+
+public:
+
+  typedef mitk::AtomicStateTransitionTester<const QmitkStdMultiWidget*, QmitkStdMultiWidgetState> ViewerStateTester;
+  typedef QmitkStdMultiWidgetState ViewerState;
+  typedef QmitkStdMultiWidgetTestClass Self;
+
+  /// \brief Constructs a QmitkStdMultiWidgetTestClass object.
+  explicit QmitkStdMultiWidgetTestClass();
+
+  /// \brief Destructs the QmitkStdMultiWidgetTestClass object.
+  virtual ~QmitkStdMultiWidgetTestClass();
+
+  /// \brief Gets the name of the image file to load into the viewer.
+  std::string GetFileName() const;
+
+  /// \brief Sets the name of the image file to load into the viewer.
+  void SetFileName(const std::string& fileName);
+
+  /// \brief Gets the interactive mode.
+  /// In interactive mode the windows are not closed when the test is finished.
+  bool GetInteractiveMode() const;
+
+  /// \brief Sets the interactive mode.
+  /// In interactive mode the windows are not closed when the test is finished.
+  void SetInteractiveMode(bool interactiveMode);
+
+  /// \brief Converts a cursor position in a render window to a point on the screen.
+  /// The cursor position is a relative position within the render window normalised to the render window size.
+  /// The bottom left position is (0.0, 0.0), the top right position is (1.0, 1.0).
+  static QPoint GetPointAtCursorPosition(QmitkRenderWindow *renderWindow, const mitk::Vector2D& cursorPosition);
+
+  /// \brief Converts a point on the screen to a cursor position in a render window.
+  /// The cursor position is a relative position within the render window normalised to the render window size.
+  /// The bottom left position is (0.0, 0.0), the top right position is (1.0, 1.0).
+  static mitk::Vector2D GetCursorPositionAtPoint(QmitkRenderWindow *renderWindow, const QPoint& point);
+
+  /// \brief Determines if two world positions are equal with the tolerance of half spacing.
+  /// Converting the positions to voxel space should result equal coordinates.
+  bool Equals(const mitk::Point3D& selectedPosition1, const mitk::Point3D& selectedPosition2);
+
+  /// \brief Determines if two cursor positions are equal with the given tolerance.
+  static bool Equals(const mitk::Vector2D& cursorPosition1, const mitk::Vector2D& cursorPosition2, double tolerance = 0.001);
+
+  /// \brief Determines if two vectors of cursor positions are equal with the given tolerance.
+  /// The function assumes that the vectors contain three elements.
+  static bool Equals(const std::vector<mitk::Vector2D>& cursorPositions1, const std::vector<mitk::Vector2D>& cursorPositions2, double tolerance = 0.001);
+
+private slots:
+
+  /// \brief Initialisation before the first test function.
+  void initTestCase();
+
+  /// \brief Clean up after the last test function.
+  void cleanupTestCase();
+
+  /// \brief Initialisation before each test function.
+  void init();
+
+  /// \brief Clean up after each test function.
+  void cleanup();
+
+  /// \brief Creates a viewer and and loads an image.
+  void testViewer();
+
+  /// \brief Resizes the viewer.
+  void testResize();
+
+private:
+
+  QScopedPointer<QmitkStdMultiWidgetTestClassPrivate> d_ptr;
+
+  Q_DECLARE_PRIVATE(QmitkStdMultiWidgetTestClass)
+  Q_DISABLE_COPY(QmitkStdMultiWidgetTestClass)
+};
+
+
+int QmitkStdMultiWidgetTest(int argc, char* argv[]);
+
+#endif

--- a/Modules/Qmitk/Testing/files.cmake
+++ b/Modules/Qmitk/Testing/files.cmake
@@ -1,3 +1,8 @@
+set(MOC_H_FILES
+  mitkQtSignalCollector.h
+  QmitkStdMultiWidgetTest.h
+)
+
 # test fails easily on MacOS, rarely on Windows, needs to be fixed before permanent activation (bug 15479)
 if (BUG_15479_FIXED)
 
@@ -6,3 +11,7 @@ if (BUG_15479_FIXED)
   )
 
 endif()
+
+set(MODULE_CUSTOM_TESTS
+  QmitkStdMultiWidgetTest.cpp
+)

--- a/Modules/Qmitk/Testing/mitkAtomicStateTransitionTester.cpp
+++ b/Modules/Qmitk/Testing/mitkAtomicStateTransitionTester.cpp
@@ -1,0 +1,210 @@
+/*=============================================================================
+
+  NifTK: A software platform for medical image computing.
+
+  Copyright (c) University College London (UCL). All rights reserved.
+
+  This software is distributed WITHOUT ANY WARRANTY; without even
+  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+  PURPOSE.
+
+  See LICENSE.txt in the top level directory for details.
+
+=============================================================================*/
+
+#include "mitkAtomicStateTransitionTester.h"
+
+#include <QTest>
+#include <QMetaObject>
+#include <QMetaMethod>
+
+/// Note that the is_pointer struct is part of the Cxx11 standard.
+
+template<typename T>
+struct is_pointer
+{
+  static const bool value = false;
+};
+
+template<typename T>
+struct is_pointer<T*>
+{
+  static const bool value = true;
+};
+
+
+namespace mitk
+{
+
+//-----------------------------------------------------------------------------
+template <class TestObject, class TestObjectState>
+AtomicStateTransitionTester<TestObject, TestObjectState>::AtomicStateTransitionTester(TestObject testObject)
+: Superclass()
+, m_TestObject(testObject)
+, m_InitialState(TestObjectState::New(testObject))
+, m_NextState(0)
+, m_ExpectedState(0)
+{
+  /// We collect the ITK signals using an ItkSignalCollector object.
+  m_ItkSignalCollector = mitk::ItkSignalCollector::New();
+  m_ItkSignalCollector->AddListener(this);
+
+  m_QtSignalCollector = mitk::QtSignalCollector::New();
+  m_QtSignalCollector->AddListener(this);
+
+  /// If the tested object is a QObject then let us discover its public signals and connect this object to them.
+  if (::is_pointer<TestObject>::value)
+  {
+    const QObject* qTestObject = dynamic_cast<const QObject*>(testObject);
+
+    if (qTestObject)
+    {
+      const QMetaObject* metaObject = qTestObject->metaObject();
+      int methodCount = metaObject->methodCount();
+      for (int i = 0; i < methodCount; ++i)
+      {
+        QMetaMethod metaMethod = metaObject->method(i);
+        if (metaMethod.methodType() == QMetaMethod::Signal)
+        {
+          /// Note:
+          /// The SIGNAL macro preprends a '2' before the signals and '1' before slots.
+          /// So that the connect mechanism works, we have to imitate this behaviour here.
+          QByteArray signal(metaMethod.signature());
+          signal.prepend('2');
+          this->Connect(qTestObject, signal);
+        }
+      }
+    }
+  }
+}
+
+
+//-----------------------------------------------------------------------------
+template <class TestObject, class TestObjectState>
+AtomicStateTransitionTester<TestObject, TestObjectState>::~AtomicStateTransitionTester()
+{
+  m_ItkSignalCollector->RemoveListener(this);
+  m_QtSignalCollector->RemoveListener(this);
+}
+
+
+//-----------------------------------------------------------------------------
+template <class TestObject, class TestObjectState>
+void AtomicStateTransitionTester<TestObject, TestObjectState>::Clear()
+{
+  m_InitialState = TestObjectState::New(m_TestObject);
+  m_NextState = 0;
+  m_ExpectedState = 0;
+
+  m_ItkSignalCollector->Clear();
+  m_QtSignalCollector->Clear();
+}
+
+
+//-----------------------------------------------------------------------------
+template <class TestObject, class TestObjectState>
+void AtomicStateTransitionTester<TestObject, TestObjectState>::CheckState()
+{
+  typename TestObjectState::Pointer newState = TestObjectState::New(m_TestObject);
+
+  if (m_NextState.IsNull())
+  {
+    if (*newState == *m_InitialState)
+    {
+      MITK_INFO << "ERROR: Illegal state. Signal received but the state of the object has not changed.";
+      MITK_INFO << typename Self::Pointer(this);
+      MITK_INFO << "ITK signals:" << std::endl;
+      MITK_INFO << m_ItkSignalCollector;
+      MITK_INFO << "Qt signals:" << std::endl;
+      MITK_INFO << m_QtSignalCollector;
+      QFAIL("Illegal state. Signal received but the state of the object has not changed.");
+    }
+    else if (m_ExpectedState.IsNotNull() && *newState != *m_ExpectedState)
+    {
+      MITK_INFO << "ERROR: Illegal state. The new state of the object is not equal to the expected state.";
+      MITK_INFO << typename Self::Pointer(this);
+      MITK_INFO << "New, illegal state:";
+      MITK_INFO << newState;
+      QFAIL("Illegal state. The new state of the object is not equal to the expected state.");
+    }
+    m_NextState = newState;
+  }
+  else if (*newState != *m_NextState)
+  {
+    MITK_INFO << "ERROR: Illegal state. The state of the object has already changed once.";
+    MITK_INFO << typename Self::Pointer(this);
+    MITK_INFO << "New, illegal state:";
+    MITK_INFO << newState;
+    MITK_INFO << "Difference between initial state and next state:";
+    m_InitialState->PrintDifference(m_NextState);
+    MITK_INFO << "Difference between next state and new state:";
+    m_NextState->PrintDifference(newState);
+    QFAIL("Illegal state. The state of the object has already changed once.");
+  }
+}
+
+
+//-----------------------------------------------------------------------------
+template <class TestObject, class TestObjectState>
+void AtomicStateTransitionTester<TestObject, TestObjectState>::PrintSelf(std::ostream & os, itk::Indent indent) const
+{
+  os << indent << "Initial state: " << std::endl;
+  os << indent << m_InitialState;
+
+  if (m_ExpectedState.IsNotNull())
+  {
+    os << indent << "Expected state: " << std::endl;
+    os << indent << m_ExpectedState;
+  }
+
+  if (m_NextState.IsNotNull())
+  {
+    os << indent << "Next state: " << std::endl;
+    os << indent << m_NextState;
+    os << indent << "ITK signals:" << std::endl;
+    os << indent << m_ItkSignalCollector;
+    os << indent << "Qt signals:" << std::endl;
+    os << indent << m_QtSignalCollector;
+  }
+}
+
+
+//-----------------------------------------------------------------------------
+template <class TestObject, class TestObjectState>
+void AtomicStateTransitionTester<TestObject, TestObjectState>::Connect(itk::Object* object, const itk::EventObject& event)
+{
+  m_ItkSignalCollector->Connect(object, event);
+}
+
+
+//-----------------------------------------------------------------------------
+template <class TestObject, class TestObjectState>
+void AtomicStateTransitionTester<TestObject, TestObjectState>::Connect(const itk::EventObject& event)
+{
+  this->Connect(m_TestObject, event);
+}
+
+
+//-----------------------------------------------------------------------------
+template <class TestObject, class TestObjectState>
+void AtomicStateTransitionTester<TestObject, TestObjectState>::Connect(const QObject* object, const char* signal)
+{
+  m_QtSignalCollector->Connect(object, signal);
+}
+
+
+//-----------------------------------------------------------------------------
+template <class TestObject, class TestObjectState>
+void AtomicStateTransitionTester<TestObject, TestObjectState>::Connect(const char* signal)
+{
+  if (::is_pointer<TestObject>::value)
+  {
+    const QObject* qTestObject = dynamic_cast<const QObject*>(m_TestObject);
+    if (qTestObject)
+    {
+      this->Connect(qTestObject, signal);
+    }
+  }
+}
+
+}

--- a/Modules/Qmitk/Testing/mitkAtomicStateTransitionTester.h
+++ b/Modules/Qmitk/Testing/mitkAtomicStateTransitionTester.h
@@ -1,0 +1,204 @@
+/*=============================================================================
+
+  NifTK: A software platform for medical image computing.
+
+  Copyright (c) University College London (UCL). All rights reserved.
+
+  This software is distributed WITHOUT ANY WARRANTY; without even
+  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+  PURPOSE.
+
+  See LICENSE.txt in the top level directory for details.
+
+=============================================================================*/
+
+#ifndef __mitkAtomicStateTransitionTester_h
+#define __mitkAtomicStateTransitionTester_h
+
+#include <mitkItkSignalCollector.h>
+#include <mitkQtSignalCollector.h>
+
+#include <QObject>
+#include <QByteArray>
+#include <QMetaObject>
+
+#include <mitkCommon.h>
+
+#include <map>
+
+namespace mitk
+{
+
+/// \class AtomicStateTransitionTester
+///
+/// \brief Test class to ensure the atomic transition from one object state to another.
+///
+/// The state of the tested object must change at most once during the execution
+/// of a public function.
+///
+/// Pattern of use:
+///
+///     typedef mitk::AtomicStateTransitionTester<Viewer, ViewerState> ViewerStateTester;
+///     ViewerStateTester::Pointer viewerStateTester = ViewerStateTester::New(viewer);
+///
+///   Connect the object to the ITK or Qt events sent out from this object or some of its aggregated objects:
+///
+///     viewer->Connect(viewer->GetAxialWindow(), mitk::FocusEvent());
+///     ...
+///     viewer->SomePublicFunction(...);
+///
+///   Check the received signals if needed:
+///
+///     QVERIFY( viewerStateTester->GetItkSignals( mitk::FocusEvent() ).size() == 1 );
+///
+///   viewerStateTester->Clear();
+///   viewer->AnotherPublicFunction(...);
+///   ...
+///
+template <class TestObject, class TestObjectState>
+class AtomicStateTransitionTester : public itk::Object, private mitk::ItkSignalListener, private mitk::QtSignalListener
+{
+public:
+
+  mitkClassMacro(AtomicStateTransitionTester, itk::Object);
+  mitkNewMacro1Param(AtomicStateTransitionTester, TestObject);
+
+  typedef mitk::ItkSignalCollector::Signal ItkSignal;
+  typedef mitk::ItkSignalCollector::Signals ItkSignals;
+
+  typedef mitk::QtSignalCollector::Signal QtSignal;
+  typedef mitk::QtSignalCollector::Signals QtSignals;
+
+  /// \brief Gets the object whose state consistency is being tested.
+  itkGetConstMacro(TestObject, TestObject);
+
+  /// \brief Gets the initial state of the test object.
+  itkGetConstMacro(InitialState, typename TestObjectState::Pointer);
+
+  /// \brief Gets the next state of the test object.
+  itkGetConstMacro(NextState, typename TestObjectState::Pointer);
+
+  /// \brief Gets the expected state of the test object.
+  itkGetConstMacro(ExpectedState, typename TestObjectState::Pointer);
+
+  /// \brief Sets the expected state of the test object.
+  itkSetMacro(ExpectedState, typename TestObjectState::Pointer);
+
+  /// \brief Clears the collected signals and resets the states.
+  virtual void Clear();
+
+  /// \brief Connects this object to the specified events of itkObject.
+  /// The consistency of the test object will be checked after these ITK events.
+  void Connect(itk::Object* itkObject, const itk::EventObject& event);
+
+  /// \brief Connects this object to the specified events of the test object.
+  /// The consistency of the test object will be checked after these ITK events.
+  /// The function assumes that the test object is an itk::Object.
+  void Connect(const itk::EventObject& event);
+
+  /// \brief Connects this object to the specified signals of the given object.
+  /// The consistency of the test object will be checked after these Qt signals.
+  /// The function assumes that the test object is a QObject.
+  void Connect(const QObject* qObject, const char* signal = 0);
+
+  /// \brief Connects this object to the specified signals of the test object.
+  /// The consistency of the test object will be checked after these Qt signals.
+  /// The function assumes that the test object is a QObject.
+  void Connect(const char* signal);
+
+  /// \brief Returns the collected ITK signals.
+  const ItkSignals& GetItkSignals() const
+  {
+    return m_ItkSignalCollector->GetSignals();
+  }
+
+  /// \brief Returns a set of the collected ITK signals that are sent from the given object,
+  /// and are of the given type or its subtype.
+  ItkSignals GetItkSignals(const itk::Object* itkObject, const itk::EventObject& event = itk::AnyEvent()) const
+  {
+    return m_ItkSignalCollector->GetSignals(itkObject, event);
+  }
+
+  /// \brief Returns a set of the collected ITK signals that are of the given type or its subtype.
+  ItkSignals GetItkSignals(const itk::EventObject& event) const
+  {
+    return m_ItkSignalCollector->GetSignals(event);
+  }
+
+  /// \brief Gets the Qt signals collected by this object.
+  const QtSignals& GetQtSignals() const
+  {
+    return m_QtSignalCollector->GetSignals();
+  }
+
+  /// \brief Returns a set of the collected Qt signals that are of the given type.
+  QtSignals GetQtSignals(const QObject* object, const char* signal = 0)
+  {
+    return m_QtSignalCollector->GetSignals(object, signal);
+  }
+
+  /// \brief Returns a set of the collected Qt signals that are sent from the given object,
+  /// and are of the given type.
+  QtSignals GetQtSignals(const char* signal)
+  {
+    return m_QtSignalCollector->GetSignals(signal);
+  }
+
+protected:
+
+  /// \brief Constructs an AtomicStateTransitionTester object.
+  AtomicStateTransitionTester(TestObject testObject);
+
+  /// \brief Destructs an AtomicStateTransitionTester object.
+  virtual ~AtomicStateTransitionTester();
+
+  /// \brief Handler for the ITK signals. Checks the consistency of the test object.
+  virtual void OnItkSignalReceived(const itk::Object* object, const itk::EventObject& event)
+  {
+    this->CheckState();
+  }
+
+  /// \brief Handler for the Qt signals. Checks the consistency of the test object.
+  virtual void OnQtSignalReceived(const QObject* object, const char* signal)
+  {
+    this->CheckState();
+  }
+
+  /// \brief Prints the collected signals to the given stream or to the standard output if no stream is given.
+  virtual void PrintSelf(std::ostream & os, itk::Indent indent) const;
+
+private:
+
+  /// \brief Called when a signal is received and checks if the state of the object is legal.
+  /// The state is illegal in any of the following cases:
+  ///
+  ///   <li>The state is equal to the initial state. Signals should not be sent out when the
+  ///       visible state of the object does not change.
+  ///   <li>The new state is not equal to the expected state when the expected state is set.
+  ///   <li>The state of the object has changed twice. Signals should be withhold until the
+  ///       object has reached its final state, and should be sent out only at that point.
+  void CheckState();
+
+  /// \brief The test object whose state consistency is being checked.
+  TestObject m_TestObject;
+
+  /// \brief The initial state of the test object.
+  typename TestObjectState::Pointer m_InitialState;
+
+  /// \brief The next state of the test object.
+  typename TestObjectState::Pointer m_NextState;
+
+  /// \brief The expected state of the test object.
+  typename TestObjectState::Pointer m_ExpectedState;
+
+  /// \brief ITK signal collector.
+  mitk::ItkSignalCollector::Pointer m_ItkSignalCollector;
+
+  /// \brief Qt signal collector.
+  mitk::QtSignalCollector::Pointer m_QtSignalCollector;
+
+};
+
+}
+
+#endif

--- a/Modules/Qmitk/Testing/mitkItkSignalCollector.cpp
+++ b/Modules/Qmitk/Testing/mitkItkSignalCollector.cpp
@@ -1,0 +1,167 @@
+/*=============================================================================
+
+  NifTK: A software platform for medical image computing.
+
+  Copyright (c) University College London (UCL). All rights reserved.
+
+  This software is distributed WITHOUT ANY WARRANTY; without even
+  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+  PURPOSE.
+
+  See LICENSE.txt in the top level directory for details.
+
+=============================================================================*/
+
+#include "mitkItkSignalCollector.h"
+
+#include <mitkSliceNavigationController.h>
+#include <mitkFocusManager.h>
+
+#include <algorithm>
+
+namespace mitk
+{
+
+//-----------------------------------------------------------------------------
+ItkSignalCollector::ItkSignalCollector()
+: itk::Command()
+{
+}
+
+
+//-----------------------------------------------------------------------------
+ItkSignalCollector::~ItkSignalCollector()
+{
+  ObserverMap::iterator observerTagIt = m_ObserverTags.begin();
+  ObserverMap::iterator observerTagEnd = m_ObserverTags.end();
+  for ( ; observerTagIt != observerTagEnd; ++observerTagIt)
+  {
+    itk::Object* object = observerTagIt->first;
+    unsigned long observerTag = observerTagIt->second;
+    object->RemoveObserver(observerTag);
+  }
+  this->Clear();
+}
+
+
+//-----------------------------------------------------------------------------
+void ItkSignalCollector::Connect(itk::Object* object, const itk::EventObject& event)
+{
+  unsigned long observerTag = object->AddObserver(event, this);
+  m_ObserverTags.insert(ObserverMap::value_type(object, observerTag));
+}
+
+
+//-----------------------------------------------------------------------------
+void ItkSignalCollector::AddListener(ItkSignalListener* listener)
+{
+  std::vector<ItkSignalListener*>::iterator it = std::find(m_Listeners.begin(), m_Listeners.end(), listener);
+  if (it == m_Listeners.end())
+  {
+    m_Listeners.push_back(listener);
+  }
+}
+
+
+//-----------------------------------------------------------------------------
+void ItkSignalCollector::RemoveListener(ItkSignalListener* listener)
+{
+  std::vector<ItkSignalListener*>::iterator it = std::find(m_Listeners.begin(), m_Listeners.end(), listener);
+  if (it != m_Listeners.end())
+  {
+    m_Listeners.erase(it);
+  }
+}
+
+
+//-----------------------------------------------------------------------------
+void ItkSignalCollector::Execute(itk::Object* caller, const itk::EventObject& event)
+{
+  this->ProcessEvent(caller, event);
+}
+
+
+//-----------------------------------------------------------------------------
+void ItkSignalCollector::Execute(const itk::Object* caller, const itk::EventObject& event)
+{
+  this->ProcessEvent(caller, event);
+}
+
+
+//-----------------------------------------------------------------------------
+void ItkSignalCollector::ProcessEvent(const itk::Object* caller, const itk::EventObject& event)
+{
+  /// Create a copy of the event as a newly allocated object.
+  m_Signals.push_back(Signal(caller, event.MakeObject()));
+
+  std::vector<ItkSignalListener*>::iterator it = m_Listeners.begin();
+  std::vector<ItkSignalListener*>::iterator listenersEnd = m_Listeners.end();
+  for ( ; it != listenersEnd; ++it)
+  {
+    (*it)->OnItkSignalReceived(caller, event);
+  }
+}
+
+
+//-----------------------------------------------------------------------------
+const ItkSignalCollector::Signals& ItkSignalCollector::GetSignals() const
+{
+  return m_Signals;
+}
+
+
+//-----------------------------------------------------------------------------
+ItkSignalCollector::Signals ItkSignalCollector::GetSignals(const itk::EventObject& event) const
+{
+  return this->GetSignals(0, event);
+}
+
+
+//-----------------------------------------------------------------------------
+ItkSignalCollector::Signals ItkSignalCollector::GetSignals(const itk::Object* object, const itk::EventObject& event) const
+{
+  Signals selectedSignals;
+  Signals::const_iterator it = m_Signals.begin();
+  Signals::const_iterator signalsEnd = m_Signals.end();
+  for ( ; it != signalsEnd; ++it)
+  {
+    Signal itkSignal = *it;
+    if ((object == 0 || object == itkSignal.first)
+        && event.CheckEvent(itkSignal.second))
+    {
+      selectedSignals.push_back(itkSignal);
+    }
+  }
+  return selectedSignals;
+}
+
+
+//-----------------------------------------------------------------------------
+void ItkSignalCollector::Clear()
+{
+  /// Destruct the copies of the original events.
+  Signals::iterator it = m_Signals.begin();
+  Signals::iterator signalsEnd = m_Signals.end();
+  for ( ; it != signalsEnd; ++it)
+  {
+    delete it->second;
+  }
+
+  /// Remove the elements.
+  m_Signals.clear();
+}
+
+
+//-----------------------------------------------------------------------------
+void ItkSignalCollector::PrintSelf(std::ostream & os, itk::Indent indent) const
+{
+  Signals::const_iterator it = m_Signals.begin();
+  Signals::const_iterator signalsEnd = m_Signals.end();
+  int i = 0;
+  for ( ; it != signalsEnd; ++it, ++i)
+  {
+    os << indent << i << ": " << ((void*) it->first) << ": " << it->second->GetEventName() << std::endl;
+  }
+}
+
+}

--- a/Modules/Qmitk/Testing/mitkItkSignalCollector.h
+++ b/Modules/Qmitk/Testing/mitkItkSignalCollector.h
@@ -1,0 +1,109 @@
+/*=============================================================================
+
+  NifTK: A software platform for medical image computing.
+
+  Copyright (c) University College London (UCL). All rights reserved.
+
+  This software is distributed WITHOUT ANY WARRANTY; without even
+  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+  PURPOSE.
+
+  See LICENSE.txt in the top level directory for details.
+
+=============================================================================*/
+
+#ifndef __mitkItkSignalCollector_h
+#define __mitkItkSignalCollector_h
+
+#include <itkCommand.h>
+#include <itkEventObject.h>
+
+#include <mitkCommon.h>
+
+#include <vector>
+
+namespace mitk
+{
+
+/// \class ItkSignalListener
+///
+/// \brief Abstract class to be implemented by ITK signal listeners.
+class ItkSignalListener
+{
+public:
+  virtual void OnItkSignalReceived(const itk::Object* object, const itk::EventObject& event) = 0;
+};
+
+
+/// \class ItkSignalCollector
+///
+/// \brief Class for collecting ITK signals and sending notifications of them to registered listeners.
+class ItkSignalCollector : public itk::Command
+{
+public:
+  mitkClassMacro(ItkSignalCollector, itk::Command);
+  itkNewMacro(ItkSignalCollector);
+
+  typedef std::pair<const itk::Object*, itk::EventObject*> Signal;
+  typedef std::vector<Signal> Signals;
+
+  /// \brief Connects this object to the events of the given object.
+  /// The current object will collect the given type of signals of that object.
+  void Connect(itk::Object* object, const itk::EventObject& event);
+
+  /// \brief Adds a listener that will get notified of the ITK signals that this object is connected to.
+  void AddListener(ItkSignalListener* listener);
+
+  /// \brief Removes a listener. The listener will not get notified about the ITK signals observed by
+  /// the current object, any more.
+  void RemoveListener(ItkSignalListener* listener);
+
+  /// \brief Gets the signals collected by this object.
+  const Signals& GetSignals() const;
+
+  /// \brief Returns a set of the collected ITK signals that are of the given type or its subtype.
+  Signals GetSignals(const itk::EventObject& event) const;
+
+  /// \brief Returns a set of the collected ITK signals that are sent from the given object,
+  /// and are of the given type or its subtype.
+  Signals GetSignals(const itk::Object* object, const itk::EventObject& event = itk::AnyEvent()) const;
+
+  /// \brief Clears all the signals collected by now.
+  virtual void Clear();
+
+  /// \brief Adds the object-event pair to the list of collected signals.
+  virtual void ProcessEvent(const itk::Object* object, const itk::EventObject& event);
+
+protected:
+
+  /// \brief Constructs an ItkSignalCollector object.
+  ItkSignalCollector();
+
+  /// \brief Destructs an ItkSignalCollector object.
+  virtual ~ItkSignalCollector();
+
+  /// \brief Prints the collected signals to the given stream or to the standard output if no stream is given.
+  virtual void PrintSelf(std::ostream & os, itk::Indent indent) const;
+
+private:
+
+  /// \brief Called when the event happens to the caller.
+  virtual void Execute(itk::Object* caller, const itk::EventObject& event);
+
+  /// \brief Called when the event happens to the caller.
+  virtual void Execute(const itk::Object* object, const itk::EventObject& event);
+
+  typedef std::multimap<itk::Object::Pointer, unsigned long> ObserverMap;
+  ObserverMap m_ObserverTags;
+
+  /// \brief The signals collected by this object.
+  Signals m_Signals;
+
+  /// \brief The listeners of the ITK signals.
+  std::vector<ItkSignalListener*> m_Listeners;
+
+};
+
+}
+
+#endif

--- a/Modules/Qmitk/Testing/mitkQtSignalCollector.cpp
+++ b/Modules/Qmitk/Testing/mitkQtSignalCollector.cpp
@@ -1,0 +1,172 @@
+/*=============================================================================
+
+  NifTK: A software platform for medical image computing.
+
+  Copyright (c) University College London (UCL). All rights reserved.
+
+  This software is distributed WITHOUT ANY WARRANTY; without even
+  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+  PURPOSE.
+
+  See LICENSE.txt in the top level directory for details.
+
+=============================================================================*/
+
+#include "mitkQtSignalCollector.h"
+
+#include <mitkSliceNavigationController.h>
+#include <mitkFocusManager.h>
+
+namespace mitk
+{
+
+//-----------------------------------------------------------------------------
+QtSignalNotifier::QtSignalNotifier(QtSignalListener* signalListener, const QObject* object, const char* signal)
+{
+  m_QtSignalListener = signalListener;
+  m_Object = object;
+  m_Signal = QMetaObject::normalizedSignature(signal);
+
+  QObject::connect(m_Object, m_Signal, this, SLOT(OnQtSignalReceived()), Qt::DirectConnection);
+}
+
+
+//-----------------------------------------------------------------------------
+QtSignalNotifier::~QtSignalNotifier()
+{
+  QObject::disconnect(m_Object, m_Signal, this, SLOT(OnQtSignalReceived()));
+}
+
+
+//-----------------------------------------------------------------------------
+void QtSignalNotifier::OnQtSignalReceived()
+{
+  m_QtSignalListener->OnQtSignalReceived(m_Object, m_Signal);
+}
+
+
+//-----------------------------------------------------------------------------
+QtSignalCollector::QtSignalCollector()
+: QObject()
+, itk::Object()
+{
+}
+
+
+//-----------------------------------------------------------------------------
+QtSignalCollector::~QtSignalCollector()
+{
+  this->Clear();
+
+  std::vector<QtSignalNotifier*>::const_iterator it = m_SignalNotifiers.begin();
+  std::vector<QtSignalNotifier*>::const_iterator signalNotifiersEnd = m_SignalNotifiers.end();
+  for ( ; it != signalNotifiersEnd; ++it)
+  {
+    delete *it;
+  }
+}
+
+
+//-----------------------------------------------------------------------------
+void QtSignalCollector::Connect(const QObject* object, const char* signal)
+{
+  QtSignalNotifier* signalNotifier = new QtSignalNotifier(this, object, signal);
+  m_SignalNotifiers.push_back(signalNotifier);
+}
+
+
+//-----------------------------------------------------------------------------
+void QtSignalCollector::AddListener(QtSignalListener* listener)
+{
+  std::vector<QtSignalListener*>::iterator it = std::find(m_Listeners.begin(), m_Listeners.end(), listener);
+  if (it == m_Listeners.end())
+  {
+    m_Listeners.push_back(listener);
+  }
+}
+
+
+//-----------------------------------------------------------------------------
+void QtSignalCollector::RemoveListener(QtSignalListener* listener)
+{
+  std::vector<QtSignalListener*>::iterator it = std::find(m_Listeners.begin(), m_Listeners.end(), listener);
+  if (it != m_Listeners.end())
+  {
+    m_Listeners.erase(it);
+  }
+}
+
+
+//-----------------------------------------------------------------------------
+QtSignalCollector::Signals QtSignalCollector::GetSignals(const char* signal) const
+{
+  return this->GetSignals(0, signal);
+}
+
+
+//-----------------------------------------------------------------------------
+QtSignalCollector::Signals QtSignalCollector::GetSignals(const QObject* object, const char* signal) const
+{
+  QByteArray normalisedSignal = QMetaObject::normalizedSignature(signal);
+  Signals selectedSignals;
+  Signals::const_iterator it = m_Signals.begin();
+  Signals::const_iterator signalsEnd = m_Signals.end();
+  for ( ; it != signalsEnd; ++it)
+  {
+    if ((object == 0 || it->first == object)
+        && (signal == 0 || it->second == normalisedSignal))
+    {
+      selectedSignals.push_back(*it);
+    }
+  }
+  return selectedSignals;
+}
+
+
+//-----------------------------------------------------------------------------
+void QtSignalCollector::OnQtSignalReceived(const QObject* object, const char* signal)
+{
+  /// Create a copy of the event as a newly allocated object.
+  m_Signals.push_back(Signal(object, signal));
+
+  std::vector<QtSignalListener*>::iterator it = m_Listeners.begin();
+  std::vector<QtSignalListener*>::iterator listenersEnd = m_Listeners.end();
+  for ( ; it != listenersEnd; ++it)
+  {
+    (*it)->OnQtSignalReceived(object, signal);
+  }
+}
+
+
+
+
+//-----------------------------------------------------------------------------
+const QtSignalCollector::Signals& QtSignalCollector::GetSignals() const
+{
+  return m_Signals;
+}
+
+
+//-----------------------------------------------------------------------------
+void QtSignalCollector::Clear()
+{
+  m_Signals.clear();
+}
+
+
+//-----------------------------------------------------------------------------
+void QtSignalCollector::PrintSelf(std::ostream & os, itk::Indent indent) const
+{
+  /// Note that the SIGNAL macro inserted a '2' character before the
+  /// signature of the signal. We do not want to print that, that is
+  /// why we step the pointer by 1 (constData() + 1).
+  Signals::const_iterator it = m_Signals.begin();
+  Signals::const_iterator signalsEnd = m_Signals.end();
+  int i = 0;
+  for ( ; it != signalsEnd; ++it, ++i)
+  {
+    os << indent << i << ": " << ((void*) it->first) << ": " << (it->second.constData() + 1) << std::endl;
+  }
+}
+
+}

--- a/Modules/Qmitk/Testing/mitkQtSignalCollector.h
+++ b/Modules/Qmitk/Testing/mitkQtSignalCollector.h
@@ -1,0 +1,131 @@
+/*=============================================================================
+
+  NifTK: A software platform for medical image computing.
+
+  Copyright (c) University College London (UCL). All rights reserved.
+
+  This software is distributed WITHOUT ANY WARRANTY; without even
+  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+  PURPOSE.
+
+  See LICENSE.txt in the top level directory for details.
+
+=============================================================================*/
+
+#ifndef __mitkQtSignalCollector_h
+#define __mitkQtSignalCollector_h
+
+#include <QObject>
+
+#include <mitkCommon.h>
+#include <itkObject.h>
+#include <itkObjectFactory.h>
+
+#include <vector>
+
+namespace mitk
+{
+
+/// \class QtSignalListener
+///
+/// \brief Abstract class to be implemented by Qt signal listeners.
+class QtSignalListener
+{
+public:
+  virtual void OnQtSignalReceived(const QObject* object, const char* signal) = 0;
+};
+
+
+/// \class QtSignalNotifier
+///
+/// \brief Helper class that implements a call back mechanism for Qt signals.
+class QtSignalNotifier : public QObject
+{
+  Q_OBJECT
+
+public:
+
+  QtSignalNotifier(QtSignalListener* signalListener, const QObject* object, const char* signal);
+
+  virtual ~QtSignalNotifier();
+
+private slots:
+
+  virtual void OnQtSignalReceived();
+
+private:
+
+  QtSignalListener* m_QtSignalListener;
+  const QObject* m_Object;
+  QByteArray m_Signal;
+};
+
+
+/// \class QtSignalCollector
+///
+/// \brief Class for collecting Qt signals and sending notifications of them to registered listeners.
+class QtSignalCollector : public QObject, public itk::Object, private QtSignalListener
+{
+  Q_OBJECT
+
+public:
+  mitkClassMacro(QtSignalCollector, QObject);
+  itkNewMacro(QtSignalCollector);
+
+  typedef std::pair<const QObject*, QByteArray> Signal;
+  typedef std::vector<Signal> Signals;
+
+  /// \brief Connects this object to the signals of the given object.
+  /// The current object will collect the given signals of that object.
+  void Connect(const QObject* object, const char* signal = 0);
+
+  /// \brief Adds a listener that will get notified of the Qt signals that this object is connected to.
+  void AddListener(QtSignalListener* listener);
+
+  /// \brief Removes a listener. The listener will not get notified about the Qt signals observed by
+  /// the current object, any more.
+  void RemoveListener(QtSignalListener* listener);
+
+  /// \brief Gets the signals collected by this object.
+  const Signals& GetSignals() const;
+
+  /// \brief Returns a set of the collected Qt signals that are of the given type.
+  Signals GetSignals(const char* signal) const;
+
+  /// \brief Returns a set of the collected Qt signals that are sent from the given object,
+  /// and are of the given type.
+  Signals GetSignals(const QObject* object, const char* signal = 0) const;
+
+  /// \brief Clears all the signals collected by now.
+  virtual void Clear();
+
+protected:
+
+  /// \brief Constructs an QtSignalCollector object.
+  QtSignalCollector();
+
+  /// \brief Destructs an QtSignalCollector object.
+  virtual ~QtSignalCollector();
+
+  /// \brief Prints the collected signals to the given stream or to the standard output if no stream is given.
+  virtual void PrintSelf(std::ostream & os, itk::Indent indent) const;
+
+  /// \brief Adds the object-signal pair to the list of collected signals.
+  virtual void OnQtSignalReceived(const QObject* object, const char* signal);
+
+private:
+
+  /// \brief The signals collected by this object.
+  Signals m_Signals;
+
+  /// \brief The signals collected by this object.
+  std::vector<QtSignalNotifier*> m_SignalNotifiers;
+
+  /// \brief The listeners of the ITK signals.
+  std::vector<QtSignalListener*> m_Listeners;
+
+};
+
+}
+
+#endif


### PR DESCRIPTION
The tester can be connected to ITK events or Qt signals of
the test object or any other object whose state should be
consistent with the test object. E.g. if you are testing
the QmitkStdMultiWidget, you might want to connect the tester
to the ITK events coming from its renderers, slice navigation
controllers, the focus manager or the display geometries.

When a signal is received, the tester checks if any state transition
has happened actually, and if new state is consistent. The
test also refuses the state transitions that happens after
receiving a signal. No signal should be sent out until the
state of the object is 'final'. Intermediate states should not be
visible.

The commit contains a unit test for QmitkStdMultiWidget.
