### PR TITLE
DataNode pointers are converted to 'unsigned long long' values, not just...

### DIFF
--- a/Modules/Python/QmitkPythonVariableStackTableModel.cpp
+++ b/Modules/Python/QmitkPythonVariableStackTableModel.cpp
@@ -65,7 +65,7 @@ bool QmitkPythonVariableStackTableModel::dropMimeData ( const QMimeData * data, 
              slIter != listOfDataNodeAddressPointers.end();
              slIter++)
         {
-          long val = (*slIter).toLong();
+          unsigned long long val = (*slIter).toULongLong();
           mitk::DataNode* node = static_cast<mitk::DataNode *>((void*)val);
           mitk::Image* mitkImage = dynamic_cast<mitk::Image*>(node->GetData());
           MITK_DEBUG("QmitkPythonVariableStackTableModel") << "mitkImage is not null " << (mitkImage != 0? "true": "false");

--- a/Modules/QtWidgets/QmitkDataStorageTreeModel.cpp
+++ b/Modules/QtWidgets/QmitkDataStorageTreeModel.cpp
@@ -179,7 +179,7 @@ bool QmitkDataStorageTreeModel::dropMimeData(const QMimeData *data,
         slIter != listOfTreeItemAddressPointers.end();
         slIter++)
     {
-      long val = (*slIter).toLong();
+      unsigned long long val = (*slIter).toULongLong();
       listOfItemsToDrop << static_cast<TreeItem *>((void*)val);
     }
 
@@ -251,7 +251,7 @@ bool QmitkDataStorageTreeModel::dropMimeData(const QMimeData *data,
          slIter != listOfDataNodeAddressPointers.end();
          slIter++)
     {
-      long val = (*slIter).toLong();
+      unsigned long long val = (*slIter).toULongLong();
       mitk::DataNode* node = static_cast<mitk::DataNode *>((void*)val);
 
       if(node && m_DataStorage.IsNotNull() && !m_DataStorage->Exists(node))
@@ -296,8 +296,8 @@ QMimeData * QmitkDataStorageTreeModel::mimeData(const QModelIndexList & indexes)
   for (int i = 0; i < indexes.size(); i++)
   {
     TreeItem* treeItem = static_cast<TreeItem*>(indexes.at(i).internalPointer());
-    long treeItemAddress = reinterpret_cast<long>(treeItem);
-    long dataNodeAddress = reinterpret_cast<long>(treeItem->GetDataNode().GetPointer());
+    unsigned long long treeItemAddress = reinterpret_cast<unsigned long long>(treeItem);
+    unsigned long long dataNodeAddress = reinterpret_cast<unsigned long long>(treeItem->GetDataNode().GetPointer());
     QTextStream(&treeItemAddresses) << treeItemAddress;
     QTextStream(&dataNodeAddresses) << dataNodeAddress;
 

--- a/Modules/QtWidgets/QmitkRenderWindow.cpp
+++ b/Modules/QtWidgets/QmitkRenderWindow.cpp
@@ -332,7 +332,7 @@ void QmitkRenderWindow::dropEvent(QDropEvent * event)
 
     for (int i = 0; i < listOfDataNodes.size(); i++)
     {
-      long val = listOfDataNodes[i].toLong();
+      unsigned long long val = listOfDataNodes[i].toULongLong();
       mitk::DataNode* node = static_cast<mitk::DataNode *>((void*) val);
       vectorOfDataNodePointers.push_back(node);
     }


### PR DESCRIPTION
... 'long' in drop events

This caused crash on Win64 with VS2012 where pointers are 8B but long is 4B.

Signed-off-by: Miklos Espak m.espak@ucl.ac.uk
