### PR TITLE
Fix leaks found by running non-rendering unit tests with VTK_DEBUG_LEAKS

### DIFF
--- a/Core/Code/DataManagement/mitkBaseGeometry.cpp
+++ b/Core/Code/DataManagement/mitkBaseGeometry.cpp
@@ -671,6 +671,7 @@ void mitk::BaseGeometry::ExecuteOperation(Operation* operation)
       vtkMatrix4x4* matrix = vtkMatrix4x4::New();
       TransferItkTransformToVtkMatrix(dynamic_cast<mitk::RestorePlanePositionOperation*>(operation)->GetTransform().GetPointer(), matrix);
       vtktransform->SetMatrix(matrix);
+      matrix->Delete();
       break;
     }
   case OpAPPLYTRANSFORMMATRIX:

--- a/Core/Code/Testing/mitkAffineTransformBaseTest.cpp
+++ b/Core/Code/Testing/mitkAffineTransformBaseTest.cpp
@@ -30,10 +30,10 @@ static Matrix3D rotation;
 static Point3D  originalPoint;
 static double   originalPointDouble[4];
 
-static vtkMatrix4x4* homogenMatrix;
+static vtkMatrix4x4* homogenMatrix = 0;
 
 
-static vtkMatrix4x4* expectedHomogenousMatrix;
+static vtkMatrix4x4* expectedHomogenousMatrix = 0;
 static const double  expectedPointAfterTransformation[] = {2, 4, 4, 1};
 
 static void Setup()
@@ -73,6 +73,12 @@ static void Setup()
   expectedHomogenousMatrix->SetElement(3,3,1);
 }
 
+static void TearDown()
+{
+  if (homogenMatrix) homogenMatrix->Delete();
+  if (expectedHomogenousMatrix) expectedHomogenousMatrix->Delete();
+}
+
 /**
 * This first test basically assures that we understand the usage of AffineTransform3D correct.
 * Meaning that the rotation is set by SetMatrix and the translation is set by SetOffset
@@ -98,6 +104,8 @@ static void testIfPointIsTransformedAsExpected(void)
     pointCorrect &= Equal(pointTransformedByAffineTransform3D[i], expectedPointAfterTransformation[i]);
 
   MITK_TEST_CONDITION(pointCorrect, "Point has been correctly transformed by AffineTranform3D")
+
+  TearDown();
 }
 
 /**
@@ -122,6 +130,8 @@ static void testTransferItkTransformToVtkMatrix(void)
       allElementsEqual &= Equal(homogenMatrix->GetElement(i,j), expectedHomogenousMatrix->GetElement(i,j));
 
   MITK_TEST_CONDITION(allElementsEqual, "Homogenous Matrix is set as expected")
+
+  TearDown();
 }
 
 /**
@@ -165,6 +175,7 @@ static void testIfBothTransformationsProduceSameResults(void)
   MITK_TEST_CONDITION(pointsMatch
     && homogenousComponentCorrect, "Point transformed by AffineTransform and homogenous coordinates match")
 
+  TearDown();
 }
 
 /**

--- a/Core/Code/Testing/mitkBaseGeometryTest.cpp
+++ b/Core/Code/Testing/mitkBaseGeometryTest.cpp
@@ -364,6 +364,7 @@ public:
     //undo changes, new and changed object need to be the same!
     vtkmatrix->SetElement(1,1,1);
     dummy->SetIndexToWorldTransformByVtkMatrix(vtkmatrix);
+    vtkmatrix->Delete();
     DummyTestClass::Pointer newDummy = DummyTestClass::New();
     CPPUNIT_ASSERT(mitk::Equal(dummy,newDummy,mitk::eps,true));
   }
@@ -561,12 +562,14 @@ public:
     DummyTestClass::Pointer dummy = DummyTestClass::New();
     dummy->SetIndexToWorldTransform(transform1);  //Spacing = 2
     dummy->Compose(vtkmatrix2); //Spacing = 4
+    vtkmatrix2->Delete();
 
     CPPUNIT_ASSERT(mitk::Equal(transform3,dummy->GetIndexToWorldTransform(),mitk::eps,true)); // 4=4
     CPPUNIT_ASSERT(mitk::Equal(dummy->GetSpacing(), expectedSpacing));
 
     //undo changes, new and changed object need to be the same!
     dummy->Compose(vtkmatrix4); //Spacing = 1
+    vtkmatrix4->Delete();
     DummyTestClass::Pointer newDummy = DummyTestClass::New();
     CPPUNIT_ASSERT(mitk::Equal(dummy,newDummy,mitk::eps,true)); // 1=1
   }

--- a/Core/Code/Testing/mitkClippedSurfaceBoundsCalculatorTest.cpp
+++ b/Core/Code/Testing/mitkClippedSurfaceBoundsCalculatorTest.cpp
@@ -339,6 +339,7 @@ static void CheckIntersectionPointsOfTwoGeometry3D(mitk::BaseGeometry::Pointer f
   MITK_INFO << "min: " << minMax.first << " max: " << minMax.second;
 
   MITK_TEST_CONDITION(minMax.first == 0 && minMax.second == 19, "Check if plane is from slice 0 to slice 19");
+  delete calculator;
 }
 
 

--- a/Core/Code/Testing/mitkLookupTableTest.cpp
+++ b/Core/Code/Testing/mitkLookupTableTest.cpp
@@ -93,6 +93,7 @@ public:
     double rgba[4];
     lut->GetTableValue(tableIndex, rgba);
     CPPUNIT_ASSERT_MESSAGE("Opacity not set for value", mitk::Equal(1.0, rgba[3], 0.01, true));
+    lut->Delete();
   }
 
   void TestCreateColorTransferFunction ()
@@ -122,6 +123,7 @@ public:
                              mitk::Equal(rgbaTable[2], rgbaFunction[2], 0.000001, true)
                              );
     }
+    lut->Delete();
   }
 
   void TestCreateOpacityTransferFunction ()
@@ -148,6 +150,7 @@ public:
                              mitk::Equal(table[i], rgba[3], 0.000001, true)
                              );
     }
+    lut->Delete();
     delete [] table;
   }
 
@@ -176,6 +179,7 @@ public:
                              mitk::Equal(table[i], rgba[3], 0.000001, true)
                              );
     }
+    lut->Delete();
     delete [] table;
   }
 };

--- a/Core/Code/Testing/vtkMitkThickSlicesFilterTest.cpp
+++ b/Core/Code/Testing/vtkMitkThickSlicesFilterTest.cpp
@@ -167,6 +167,8 @@ int vtkMitkThickSlicesFilterTest(int argc, char** const argv)
   thickSliceFilter->Update();
   vtkMitkThickSlicesFilterTestHelper::EvaluateResult( 6, thickSliceFilter->GetOutput(), "Mean" );
 
+  thickSliceFilter->Delete();
+
   MITK_TEST_END()
 }
 

--- a/Modules/IGT/TrackingDevices/mitkTrackingVolumeGenerator.cpp
+++ b/Modules/IGT/TrackingDevices/mitkTrackingVolumeGenerator.cpp
@@ -70,7 +70,10 @@ void mitk::TrackingVolumeGenerator::GenerateData()
   }
   if (filename.compare("") == 0) // empty String means no model, return empty output
   {
-    output->SetVtkPolyData(vtkPolyData::New()); //initialize with empty poly data (otherwise old surfaces may be returned) => so an empty surface is returned
+    // initialize with empty poly data (otherwise old surfaces may be returned) => so an empty surface is returned
+    vtkPolyData *emptyPolyData = vtkPolyData::New();
+    output->SetVtkPolyData(emptyPolyData);
+    emptyPolyData->Delete();
     return;
   }
 


### PR DESCRIPTION
Summary of tests that failed when built against a VTK library with VTK_DEBUG_LEAKS enabled:

mitkSliceNavigationControllerTest -- FIXED in Core/Code/DataManagement/mitkBaseGeometry.cpp
vtkMitkThickSlicesFilterTest -- FIXED in Core/Code/Testing/vtkMitkThickSlicesFilterTest.cpp
mitkClippedSurfaceBoundsCalculatorTest -- FIXED in Core/Code/Testing/mitkClippedSurfaceBoundsCalculatorTest.cpp
mitkAffineTransformBaseTest -- FIXED in Core/Code/Testing/mitkAffineTransformBaseTest.cpp
mitkLookupTableTest -- FIXED in Core/Code/Testing/mitkLookupTableTest.cpp
mitkBaseGeometryTest -- FIXED in Core/Code/Testing/mitkBaseGeometryTest.cpp
mitkTrackingVolumeGeneratorTest -- FIXED in Modules/IGT/TrackingDevices/mitkTrackingVolumeGenerator.cpp

Signed-off-by: Taylor Braun-Jones taylor.braun-jones@ge.com
