### PR TITLE
repair OpenViewCore build

### DIFF
--- a/Modules/OpenViewCore/CMakeLists.txt
+++ b/Modules/OpenViewCore/CMakeLists.txt
@@ -1,4 +1,4 @@
 MITK_CREATE_MODULE(
-  PACKAGE_DEPENDS Qt5|Core+Quick VTK|vtkGUISupportQt OpenGL
+  PACKAGE_DEPENDS Qt5|Core+Quick VTK OpenGL
   )
 


### PR DESCRIPTION
revert CMake change  https://github.com/MITK/MITK/commit/cae5120945504022681eb879b1531732f953fe78

error: `unresolved external symbol "void __cdecl vtkRenderingFreeType_AutoInit_Construct(void)`