### PR TITLE
fix for bug 19635

### DIFF
--- a/Modules/AppUtil/include/mitkBaseApplication.h
+++ b/Modules/AppUtil/include/mitkBaseApplication.h
@@ -106,6 +106,8 @@ public:
   static QString ARG_NO_LAZY_REGISTRY_CACHE_LOADING;
   static QString ARG_REGISTRY_MULTI_LANGUAGE;
 
+  static QString ARG_SPLASH_IMAGE;
+
   static QString ARG_XARGS;
 
   // BlueBerry specific Plugin Framework properties
@@ -312,6 +314,12 @@ protected:
    * @return The initial CTK Plugin Framework properties.
    */
   QHash<QString, QVariant> getFrameworkProperties() const;
+
+  /*
+  * Initialize and display the splash screen if an image filename is given
+  *
+  */
+  void initializeSplashScreen(QCoreApplication * application) const;
 
 private:
 

--- a/Modules/AppUtil/src/mitkBaseApplication.cpp
+++ b/Modules/AppUtil/src/mitkBaseApplication.cpp
@@ -30,6 +30,10 @@ See LICENSE.txt or http://www.mitk.org for details.
 
 #include <Poco/Util/HelpFormatter.h>
 
+#include <QSplashscreen>
+#include <QRunnable> 
+#include <QFileInfo>
+
 #include <QTime>
 #include <QDir>
 #include <QDesktopServices>
@@ -57,6 +61,8 @@ QString BaseApplication::ARG_CONSOLELOG = "BlueBerry.consoleLog";
 QString BaseApplication::ARG_TESTPLUGIN = "BlueBerry.testplugin";
 QString BaseApplication::ARG_TESTAPPLICATION = "BlueBerry.testapplication";
 
+QString BaseApplication::ARG_SPLASH_IMAGE = "BlueBerry.splashscreen";
+
 QString BaseApplication::ARG_NO_REGISTRY_CACHE = "BlueBerry.noRegistryCache";
 QString BaseApplication::ARG_NO_LAZY_REGISTRY_CACHE_LOADING = "BlueBerry.noLazyRegistryCacheLoading";
 QString BaseApplication::ARG_REGISTRY_MULTI_LANGUAGE = "BlueBerry.registryMultiLanguage";
@@ -76,6 +82,19 @@ QString BaseApplication::PROP_TESTPLUGIN = "BlueBerry.testplugin";
 QString BaseApplication::PROP_TESTAPPLICATION = "BlueBerry.testapplication";
 
 
+class SplashCloserCallback : public QRunnable
+{
+public:
+  SplashCloserCallback(QSplashScreen* splashscreen) {
+    this->m_Splashscreen = splashscreen;
+  }
+  void SplashCloserCallback::run() {
+    this->m_Splashscreen->close();
+  }
+private:
+  QSplashScreen* m_Splashscreen;
+};
+
 struct BaseApplication::Impl
 {
   ctkProperties m_FWProps;
@@ -91,6 +110,9 @@ struct BaseApplication::Impl
 
   bool m_SingleMode;
   bool m_SafeMode;
+  
+  QSplashScreen* m_Splashscreen;
+  SplashCloserCallback* m_SplashscreenClosingCallback;
 
   QStringList m_PreloadLibs;
   QString m_ProvFile;
@@ -100,6 +122,8 @@ struct BaseApplication::Impl
     , m_Argv(argv)
     , m_SingleMode(false)
     , m_SafeMode(true)
+    ,m_Splashscreen(0)
+    , m_SplashscreenClosingCallback(NULL)
   {
 #ifdef Q_OS_MAC
     /*
@@ -300,6 +324,7 @@ struct BaseApplication::Impl
     }
   }
 
+
 };
 
 BaseApplication::BaseApplication(int argc, char** argv)
@@ -310,7 +335,14 @@ BaseApplication::BaseApplication(int argc, char** argv)
 
 BaseApplication::~BaseApplication()
 {
-
+  if (d->m_Splashscreen != 0)
+  {
+    delete(d->m_Splashscreen);
+  }
+  if (d->m_SplashscreenClosingCallback != 0)
+  {
+    delete(d->m_SplashscreenClosingCallback);
+  }
 }
 
 void BaseApplication::printHelp(const std::string& /*name*/, const std::string& /*value*/)
@@ -516,14 +548,18 @@ void BaseApplication::initialize(Poco::Util::Application& self)
   //    framework properties.
   d->initializeCTKPluginFrameworkProperties(this->config());
 
-  // 6. Set the custom CTK Plugin Framework storage directory
+  // 6. Initialize splash screen if an image path is provided
+  //    in the .ini file
+  this->initializeSplashScreen(qApp);
+
+  // 7. Set the custom CTK Plugin Framework storage directory
   QString storageDir = this->getCTKFrameworkStorageDir();
   if (!storageDir.isEmpty())
   {
     d->m_FWProps[ctkPluginConstants::FRAMEWORK_STORAGE] = storageDir;
   }
 
-  // 7. Set the library search paths and the pre-load library property
+  // 8. Set the library search paths and the pre-load library property
   this->initializeLibraryPaths();
   QStringList preloadLibs = this->getPreloadLibraries();
   if (!preloadLibs.isEmpty())
@@ -531,13 +567,13 @@ void BaseApplication::initialize(Poco::Util::Application& self)
       d->m_FWProps[ctkPluginConstants::FRAMEWORK_PRELOAD_LIBRARIES] = preloadLibs;
   }
 
-  // 8. Initialize the CppMicroServices library.
+  // 9. Initialize the CppMicroServices library.
   //    The initializeCppMicroServices() method reuses the
   //    FRAMEWORK_STORAGE property, so we call it after the
   //    getCTKFrameworkStorageDir method.
   this->initializeCppMicroServices();
 
-  // 9. Parse the (optional) provisioning file and set the
+  // 10. Parse the (optional) provisioning file and set the
   //    correct framework properties.
   d->parseProvisioningFile(this->getProvisioningFilePath());
 
@@ -683,7 +719,14 @@ int BaseApplication::main(const std::vector<std::string>& args)
     arguments.push_back(QString::fromStdString(arg));
   }
 
-  return ctkPluginFrameworkLauncher::run(NULL, QVariant::fromValue(arguments)).toInt();
+  if (d->m_Splashscreen != 0)
+  {
+    // a splash screen is displayed,
+    // creating the closing callback
+    d->m_SplashscreenClosingCallback = new SplashCloserCallback(d->m_Splashscreen);
+  }
+
+  return ctkPluginFrameworkLauncher::run(d->m_SplashscreenClosingCallback, QVariant::fromValue(arguments)).toInt();
 }
 
 void BaseApplication::defineOptions(Poco::Util::OptionSet& options)
@@ -752,6 +795,10 @@ void BaseApplication::defineOptions(Poco::Util::OptionSet& options)
   registryMultiLanguageOption.callback(Poco::Util::OptionCallback<Impl>(d.data(), &Impl::handleBooleanOption));
   options.addOption(registryMultiLanguageOption);
 
+  Poco::Util::Option splashScreenOption(ARG_SPLASH_IMAGE.toStdString(), "", "optional picture to use as a splash screen");
+  splashScreenOption.argument("<filename>").binding(ARG_SPLASH_IMAGE.toStdString());
+  options.addOption(splashScreenOption);
+
   Poco::Util::Option xargsOption(ARG_XARGS.toStdString(), "", "Extended argument list");
   xargsOption.argument("<args>").binding(ARG_XARGS.toStdString());
   options.addOption(xargsOption);
@@ -775,6 +822,21 @@ ctkPluginContext* BaseApplication::getFrameworkContext() const
 QHash<QString, QVariant> BaseApplication::getFrameworkProperties() const
 {
   return d->m_FWProps;
+}
+
+void BaseApplication::initializeSplashScreen(QCoreApplication * application) const
+{
+  QVariant pixmapFileNameProp = d->getProperty(ARG_SPLASH_IMAGE);
+  if (!pixmapFileNameProp.isNull()) {
+    QString pixmapFileName = pixmapFileNameProp.toString();
+    QFileInfo checkFile(pixmapFileName);
+    if (checkFile.exists() && checkFile.isFile()) {
+      QPixmap pixmap(checkFile.absoluteFilePath());
+      d->m_Splashscreen = new QSplashScreen(pixmap, Qt::WindowStaysOnTopHint);
+      d->m_Splashscreen->show();
+      application->processEvents();
+    }
+  }
 }
 
 int BaseApplication::run()


### PR DESCRIPTION
- Added a configuration option which allow to give an image
  filename used as splash screen
- Added a inner QRunnable which allow CTK to close the splash
  screen once the platform is started

Signed-off-by: Aurélien Labrosse aurelien@pollen-metrology.com
