### PR TITLE
Fix for crash, described in bug#19801

### DIFF
--- a/Modules/Core/src/Interactions/mitkDispatcher.cpp
+++ b/Modules/Core/src/Interactions/mitkDispatcher.cpp
@@ -170,8 +170,13 @@ bool mitk::Dispatcher::ProcessEvent(InteractionEvent* event)
     for ( it=tmpInteractorList.cbegin(); it!=tmpInteractorList.cend(); ++it )
     {
       if ((*it).IsNotNull() && (*it)->HandleEvent(event, (*it)->GetDataNode()))
-      { // if an event is handled several properties are checked, in order to determine the processing mode of the dispatcher
-        SetEventProcessingMode(*it);
+      { 
+        // Interactor can be deleted during HandleEvent(), so check it again
+        if ((*it).IsNotNull()) 
+        {
+          // if an event is handled several properties are checked, in order to determine the processing mode of the dispatcher
+          SetEventProcessingMode(*it);
+        }
         if (std::strcmp(p->GetNameOfClass(), "MousePressEvent") == 0 && m_ProcessingMode == REGULAR)
         {
           m_SelectedInteractor = *it;


### PR DESCRIPTION
Interactor from (*it) can be deleted during HandleEvent(), so added additional check.
Otherwise there will be a crash, described in http://bugs.mitk.org/show_bug.cgi?id=19801

Signed-off-by: Alexander Kuznetsov <alexander.ev.kuznetsov@gmail.com>