### PR TITLE
Flag to suppress processing command line args

### DIFF
--- a/Plugins/org.mitk.gui.qt.ext/src/internal/QmitkCommonExtPlugin.cpp
+++ b/Plugins/org.mitk.gui.qt.ext/src/internal/QmitkCommonExtPlugin.cpp
@@ -57,13 +57,18 @@ void QmitkCommonExtPlugin::start(ctkPluginContext* context)
 
   BERRY_REGISTER_EXTENSION_CLASS(QmitkModuleView, context)
 
-  if (qApp->metaObject()->indexOfSignal("messageReceived(QByteArray)") > -1)
-  {
-    connect(qApp, SIGNAL(messageReceived(QByteArray)), this, SLOT(handleIPCMessage(QByteArray)));
-  }
+  QVariant processArgsByMITKProperty = context->getProperty("applicationArgs.processByMITK");
 
-  // This is a potentially long running operation.
-  loadDataFromDisk(berry::Platform::GetApplicationArgs(), true);
+  if (!processArgsByMITKProperty.isValid() || processArgsByMITKProperty.toBool())
+  {
+    if (qApp->metaObject()->indexOfSignal("messageReceived(QByteArray)") > -1)
+    {
+      connect(qApp, SIGNAL(messageReceived(QByteArray)), this, SLOT(handleIPCMessage(QByteArray)));
+    }
+
+    // This is a potentially long running operation.
+    loadDataFromDisk(berry::Platform::GetApplicationArgs(), true);
+  }
 }
 
 void QmitkCommonExtPlugin::stop(ctkPluginContext* context)


### PR DESCRIPTION
The flag is called 'applicationArgs.processByMITK'. If the flag is not
defined or it evaluates to 'true', the arguments are processed by MITK,
just like until now. It is possible, however, that custom applications
set this flag to 'false', so that they can introduce new switches or
options. (They could remove the dependency on the org.mitk.gui.qt.ext
module, but then they could not reuse other classes from it.)

To suppress processing the command line arguments, you need to put
this line into the main cpp file of your application:

  myApp.setProperty("applicationArgs.processByMITK", false);

where 'myApp' is typically an mitk::BaseApplication instance.

Signed-off-by: Miklos Espak <m.espak@ucl.ac.uk>