### PR TITLE
Nodes are inserted in data manager at position according to their layer

### DIFF
--- a/Plugins/org.mitk.gui.qt.datamanager/src/QmitkDataManagerView.cpp
+++ b/Plugins/org.mitk.gui.qt.datamanager/src/QmitkDataManagerView.cpp
@@ -122,10 +122,8 @@ void QmitkDataManagerView::CreateQtPartControl(QWidget* parent)
       , &QmitkDataManagerView::OnPreferencesChanged ) );
 
   //# GUI
-  m_NodeTreeModel = new QmitkDataStorageTreeModel(this->GetDataStorage());
+  m_NodeTreeModel = new QmitkDataStorageTreeModel(this->GetDataStorage(), prefs->GetBool("Place new nodes on top", true));
   m_NodeTreeModel->setParent( parent );
-  m_NodeTreeModel->SetPlaceNewNodesOnTop(
-      prefs->GetBool("Place new nodes on top", true) );
   m_SurfaceDecimation = prefs->GetBool("Use surface decimation", false);
   // Prepare filters
   m_HelperObjectFilterPredicate = mitk::NodePredicateOr::New(


### PR DESCRIPTION
When the data manager was initialised from a data storage or when
new data nodes were added, the nodes were added to the top or the
bottom under their source nodes, depending on the value of the
"Place new nodes on top" preference.

Beside this, when the data manager was initialised, the data nodes
were added in the same order in which they appeared in the data
structure retrieved from the data storage. However, in this data
structure the nodes are ordered by their smart pointer what makes
the final order in the data manager indeterministic.

The current commit inserts the nodes at the position according to
their layer, unless the the preference is set, in which case it
inserts the nodes at the top. This is when adding new nodes to the
data storage. When initialising the data manager from a data storage,
the data nodes are always inserted in the order of their layer.
(The preference is temporarily disabled for the time of initialisation.)

Signed-off-by: Miklos Espak m.espak@ucl.ac.uk
