### PR TITLE
Fix crash in RT Dose Visualization

### DIFF
--- a/Plugins/org.mitk.gui.qt.dosevisualization/src/internal/RTDoseVisualizer.cpp
+++ b/Plugins/org.mitk.gui.qt.dosevisualization/src/internal/RTDoseVisualizer.cpp
@@ -699,8 +699,14 @@ mitk::DataNode::Pointer RTDoseVisualizer::GetIsoDoseNode(mitk::DataNode::Pointer
 bool RTDoseVisualizer::ModalityIsRTDose(const mitk::DataNode* dataNode) const
 {
     auto data = dataNode->GetData();
+    if (!data) {
+      return false;
+    }
     auto modalityProperty = data->GetProperty("modality");
     auto modalityGenericProperty = dynamic_cast<mitk::GenericProperty<std::string>*>(modalityProperty.GetPointer());
+    if (!modalityGenericProperty) {
+      return false;
+    }
     std::string modality = modalityGenericProperty->GetValue();
     return modality == "RTDOSE";
 }


### PR DESCRIPTION
ModalityIsRTDose() is called on node change.
But if there is no data in node or data doesn't have "modality" property, there will be access violation and crash.
