### PR TITLE
mark Linux only checks

### DIFF
--- a/SuperBuild.cmake
+++ b/SuperBuild.cmake
@@ -21,7 +21,7 @@ endmacro()
 # MITK Prerequisites
 #-----------------------------------------------------------------------------
 
-if(UNIX AND NOT APPLE)
+if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
 
   include(mitkFunctionCheckPackageHeader)
 


### PR DESCRIPTION
those checks are Linux only actually, they are not actual either for BSD and Cygwin