### PR TITLE
Used mitk::LocaleSwitch to change locale

### DIFF
--- a/Modules/Classification/CLLibSVM/src/svm.cpp
+++ b/Modules/Classification/CLLibSVM/src/svm.cpp
@@ -58,6 +58,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <stdarg.h>
 #include <limits.h>
 #include <locale.h>
+#include <mitkLocaleSwitch.h>
 #include "svm.h"
 int libsvm_version = LIBSVM_VERSION;
 typedef float Qfloat;
@@ -2795,8 +2796,7 @@ int svm_save_model(const char *model_file_name, const svm_model *model)
   FILE *fp = fopen(model_file_name,"w");
   if(fp==NULL) return -1;
 
-  char *old_locale = strdup(setlocale(LC_ALL, NULL));
-  setlocale(LC_ALL, "C");
+  mitk::LocaleSwitch localeSwitch("C");
 
   const svm_parameter& param = model->param;
 
@@ -2876,9 +2876,6 @@ int svm_save_model(const char *model_file_name, const svm_model *model)
       }
     fprintf(fp, "\n");
   }
-
-  setlocale(LC_ALL, old_locale);
-  free(old_locale);
 
   if (ferror(fp) != 0 || fclose(fp) != 0) return -1;
   else return 0;
@@ -3027,8 +3024,7 @@ svm_model *svm_load_model(const char *model_file_name)
   FILE *fp = fopen(model_file_name,"rb");
   if(fp==NULL) return NULL;
 
-  char *old_locale = strdup(setlocale(LC_ALL, NULL));
-  setlocale(LC_ALL, "C");
+  mitk::LocaleSwitch localeSwitch("C");
 
   // read parameters
 
@@ -3044,8 +3040,6 @@ svm_model *svm_load_model(const char *model_file_name)
   if (!read_model_header(fp, model))
   {
     fprintf(stderr, "ERROR: fscanf failed to read model\n");
-    setlocale(LC_ALL, old_locale);
-    free(old_locale);
     free(model->rho);
     free(model->label);
     free(model->nSV);
@@ -3116,9 +3110,6 @@ svm_model *svm_load_model(const char *model_file_name)
     x_space[j++].index = -1;
   }
   free(line);
-
-  setlocale(LC_ALL, old_locale);
-  free(old_locale);
 
   if (ferror(fp) != 0 || fclose(fp) != 0)
     return NULL;

--- a/Modules/Core/files.cmake
+++ b/Modules/Core/files.cmake
@@ -236,6 +236,7 @@ set(CPP_FILES
   IO/mitkItkLoggingAdapter.cpp
   IO/mitkLegacyFileReaderService.cpp
   IO/mitkLegacyFileWriterService.cpp
+  IO/mitkLocaleSwitch.cpp
   IO/mitkLog.cpp
   IO/mitkMimeType.cpp
   IO/mitkMimeTypeProvider.cpp

--- a/Modules/Core/include/mitkLocaleSwitch.h
+++ b/Modules/Core/include/mitkLocaleSwitch.h
@@ -18,12 +18,6 @@ See LICENSE.txt or http://www.mitk.org for details.
 #define __mitkLocaleSwitch_h
 
 #include "MitkCoreExports.h"
-#include "mitkLogMacros.h"
-
-#include <clocale>
-#include <string>
-
-#pragma warning(disable:4251)
 
 namespace mitk
 {
@@ -53,44 +47,19 @@ namespace mitk
   }
   \endcode
 */
+
 struct MITKCORE_EXPORT LocaleSwitch
 {
-  LocaleSwitch(const std::string& newLocale)
-  : m_NewLocale( newLocale )
-  {
-    // query and keep the current locale
-    const char* currentLocale = std::setlocale(LC_ALL, nullptr);
-    if (currentLocale != nullptr)
-        m_OldLocale = currentLocale;
-    else
-        m_OldLocale = "";
+  explicit LocaleSwitch(const char* newLocale);
 
-    // install the new locale if it different from the current one
-    if (m_NewLocale != m_OldLocale)
-    {
-      if ( ! std::setlocale(LC_ALL, m_NewLocale.c_str()) )
-      {
-        MITK_INFO << "Could not switch to locale " << m_NewLocale;
-        m_OldLocale = "";
-      }
-    }
-  }
+  ~LocaleSwitch();
 
-  ~LocaleSwitch()
-  {
-    if ( !m_OldLocale.empty() && m_OldLocale != m_NewLocale && !std::setlocale(LC_ALL, m_OldLocale.c_str()) )
-    {
-      MITK_INFO << "Could not reset original locale " << m_OldLocale;
-    }
-  }
-
+  LocaleSwitch(LocaleSwitch&) = delete;
+  LocaleSwitch operator=(LocaleSwitch&) = delete;
 private:
 
-  /// locale at instantiation of object
-  std::string m_OldLocale;
-
-  /// locale during life-time of object
-  const std::string m_NewLocale;
+  struct Impl;
+  Impl* m_LocaleSwitchImpl;
 };
 
 }

--- a/Modules/Core/include/mitkLocaleSwitch.h
+++ b/Modules/Core/include/mitkLocaleSwitch.h
@@ -18,8 +18,12 @@ See LICENSE.txt or http://www.mitk.org for details.
 #define __mitkLocaleSwitch_h
 
 #include "MitkCoreExports.h"
+#include "mitkLogMacros.h"
 
 #include <clocale>
+#include <string>
+
+#pragma warning(disable:4251)
 
 namespace mitk
 {

--- a/Modules/Core/src/IO/mitkDicomSeriesReader.cpp
+++ b/Modules/Core/src/IO/mitkDicomSeriesReader.cpp
@@ -20,6 +20,7 @@ See LICENSE.txt or http://www.mitk.org for details.
 #include <mitkDicomSeriesReader.h>
 #include <mitkImage.h>
 #include <mitkImageCast.h>
+#include <mitkLocaleSwitch.h>
 
 #include <itkGDCMSeriesFileNames.h>
 
@@ -1448,9 +1449,8 @@ void DicomSeriesReader::FixSpacingInformation( mitk::Image* image, const ImageBl
 
 void DicomSeriesReader::LoadDicom(const StringContainer &filenames, DataNode &node, bool sort, bool load4D, bool correctTilt, UpdateCallBackMethod callback, Image::Pointer preLoadedImageBlock)
 {
-  const char* previousCLocale = setlocale(LC_NUMERIC, nullptr);
-  setlocale(LC_NUMERIC, "C");
-  std::locale previousCppLocale( std::cin.getloc() );
+  mitk::LocaleSwitch localeSwitch("C");
+  std::locale previousCppLocale(std::cin.getloc());
   std::locale l( "C" );
   std::cin.imbue(l);
 
@@ -1569,7 +1569,6 @@ void DicomSeriesReader::LoadDicom(const StringContainer &filenames, DataNode &no
 
       node.SetData( image );
       node.SetName(patientName);
-      setlocale(LC_NUMERIC, previousCLocale);
       std::cin.imbue(previousCppLocale);
     }
 
@@ -1586,7 +1585,6 @@ void DicomSeriesReader::LoadDicom(const StringContainer &filenames, DataNode &no
   catch (std::exception& e)
   {
     // reset locale then throw up
-    setlocale(LC_NUMERIC, previousCLocale);
     std::cin.imbue(previousCppLocale);
 
     MITK_DEBUG << "Caught exception in DicomSeriesReader::LoadDicom";

--- a/Modules/Core/src/IO/mitkDicomSeriesReaderService.cpp
+++ b/Modules/Core/src/IO/mitkDicomSeriesReaderService.cpp
@@ -19,6 +19,7 @@ See LICENSE.txt or http://www.mitk.org for details.
 #include <mitkCustomMimeType.h>
 #include <mitkIOMimeTypes.h>
 #include <mitkDicomSeriesReader.h>
+#include <mitkLocaleSwitch.h>
 #include <mitkProgressBar.h>
 #include <mitkImage.h>
 
@@ -36,9 +37,8 @@ std::vector<itk::SmartPointer<BaseData> > DicomSeriesReaderService::Read()
 {
   std::vector<BaseData::Pointer> result;
 
-  const char* previousCLocale = setlocale(LC_NUMERIC, NULL);
-  setlocale(LC_NUMERIC, "C");
-  std::locale previousCppLocale( std::cin.getloc() );
+  mitk::LocaleSwitch localeSwitch("C");
+  std::locale previousCppLocale(std::cin.getloc());
   std::locale l( "C" );
   std::cin.imbue(l);
 
@@ -56,7 +56,6 @@ std::vector<itk::SmartPointer<BaseData> > DicomSeriesReaderService::Read()
       data->GetPropertyList()->SetProperty("name", nameProp);
       result.push_back(data);
     }
-    setlocale(LC_NUMERIC, previousCLocale);
     std::cin.imbue(previousCppLocale);
     return result;
 
@@ -120,7 +119,6 @@ std::vector<itk::SmartPointer<BaseData> > DicomSeriesReaderService::Read()
     ProgressBar::GetInstance()->Progress();
   }
 
-  setlocale(LC_NUMERIC, previousCLocale);
   std::cin.imbue(previousCppLocale);
 
   return result;

--- a/Modules/Core/src/IO/mitkItkImageIO.cpp
+++ b/Modules/Core/src/IO/mitkItkImageIO.cpp
@@ -213,21 +213,7 @@ std::vector<TimePointType> ConvertMetaDataObjectToTimePointList(const itk::MetaD
 std::vector<BaseData::Pointer> ItkImageIO::Read()
 {
   std::vector<BaseData::Pointer> result;
-
-  const std::string& locale = "C";
-  const std::string& currLocale = setlocale( LC_ALL, NULL );
-
-  if ( locale.compare(currLocale)!=0 )
-  {
-    try
-    {
-      setlocale(LC_ALL, locale.c_str());
-    }
-    catch(...)
-    {
-      MITK_INFO << "Could not set locale " << locale;
-    }
-  }
+  mitk::LocaleSwitch localeSwitch("C");
 
   Image::Pointer image = Image::New();
 
@@ -464,15 +450,6 @@ std::vector<BaseData::Pointer> ItkImageIO::Read()
   }
 
   MITK_INFO << "...finished!" << std::endl;
-
-  try
-  {
-    setlocale(LC_ALL, currLocale.c_str());
-  }
-  catch(...)
-  {
-    MITK_INFO << "Could not reset locale " << currLocale;
-  }
 
   result.push_back(image.GetPointer());
   return result;

--- a/Modules/Core/src/IO/mitkLocaleSwitch.cpp
+++ b/Modules/Core/src/IO/mitkLocaleSwitch.cpp
@@ -68,8 +68,9 @@ LocaleSwitch::Impl::~Impl()
 }
 
 LocaleSwitch::LocaleSwitch(const char* newLocale)
+  : m_LocaleSwitchImpl(new Impl(newLocale))
 {
-  m_LocaleSwitchImpl = new Impl(newLocale);
+  
 }
 
 LocaleSwitch::~LocaleSwitch()

--- a/Modules/Core/src/IO/mitkLocaleSwitch.cpp
+++ b/Modules/Core/src/IO/mitkLocaleSwitch.cpp
@@ -1,0 +1,80 @@
+/*===================================================================
+
+The Medical Imaging Interaction Toolkit (MITK)
+
+Copyright (c) German Cancer Research Center,
+Division of Medical and Biological Informatics.
+All rights reserved.
+
+This software is distributed WITHOUT ANY WARRANTY; without
+even the implied warranty of MERCHANTABILITY or FITNESS FOR
+A PARTICULAR PURPOSE.
+
+See LICENSE.txt or http://www.mitk.org for details.
+
+===================================================================*/
+
+#include "mitkLocaleSwitch.h"
+
+#include "mitkLogMacros.h"
+
+#include <clocale>
+#include <string>
+
+namespace mitk {
+
+struct LocaleSwitch::Impl
+{
+  explicit Impl(const std::string& newLocale);
+
+  ~Impl();
+
+private:
+
+  /// locale at instantiation of object
+  std::string m_OldLocale;
+
+  /// locale during life-time of object
+  const std::string m_NewLocale;
+};
+
+LocaleSwitch::Impl::Impl(const std::string& newLocale)
+  : m_NewLocale(newLocale)
+{
+  // query and keep the current locale
+  const char* currentLocale = std::setlocale(LC_ALL, nullptr);
+  if (currentLocale != nullptr)
+    m_OldLocale = currentLocale;
+  else
+    m_OldLocale = "";
+
+  // install the new locale if it different from the current one
+  if (m_NewLocale != m_OldLocale)
+  {
+    if (!std::setlocale(LC_ALL, m_NewLocale.c_str()))
+    {
+      MITK_INFO << "Could not switch to locale " << m_NewLocale;
+      m_OldLocale = "";
+    }
+  }
+}
+
+LocaleSwitch::Impl::~Impl()
+{
+  if (!m_OldLocale.empty() && m_OldLocale != m_NewLocale && !std::setlocale(LC_ALL, m_OldLocale.c_str()))
+  {
+    MITK_INFO << "Could not reset original locale " << m_OldLocale;
+  }
+}
+
+LocaleSwitch::LocaleSwitch(const char* newLocale)
+{
+  m_LocaleSwitchImpl = new Impl(newLocale);
+}
+
+LocaleSwitch::~LocaleSwitch()
+{
+  delete m_LocaleSwitchImpl;
+}
+
+}

--- a/Modules/Core/src/IO/mitkSurfaceStlIO.cpp
+++ b/Modules/Core/src/IO/mitkSurfaceStlIO.cpp
@@ -127,7 +127,6 @@ void SurfaceStlIO::Write()
   LocaleSwitch localeSwitch("C");
 
   ValidateOutputLocation();
-
   const Surface* input = dynamic_cast<const Surface*>(this->GetInput());
 
   const unsigned int timesteps = input->GetTimeGeometry()->CountTimeSteps();

--- a/Modules/DICOMReaderServices/src/mitkBaseDICOMReaderService.cpp
+++ b/Modules/DICOMReaderServices/src/mitkBaseDICOMReaderService.cpp
@@ -24,6 +24,7 @@ See LICENSE.txt or http://www.mitk.org for details.
 #include <mitkDICOMTagHelper.h>
 #include <mitkDICOMProperty.h>
 #include <mitkDicomSeriesReader.h>
+#include <mitkLocaleSwitch.h>
 #include <iostream>
 
 namespace mitk {
@@ -44,8 +45,7 @@ std::vector<itk::SmartPointer<BaseData> > BaseDICOMReaderService::Read()
   if (DicomSeriesReader::IsPhilips3DDicom(fileName))
   {
       MITK_INFO << "it is a Philips3D US Dicom file" << std::endl;
-      const char* previousCLocale = setlocale(LC_NUMERIC, NULL);
-      setlocale(LC_NUMERIC, "C");
+      mitk::LocaleSwitch localeSwitch("C");
       std::locale previousCppLocale(std::cin.getloc());
       std::locale l("C");
       std::cin.imbue(l);
@@ -60,7 +60,6 @@ std::vector<itk::SmartPointer<BaseData> > BaseDICOMReaderService::Read()
           data->GetPropertyList()->SetProperty("name", nameProp);
           result.push_back(data);
       }
-      setlocale(LC_NUMERIC, previousCLocale);
       std::cin.imbue(previousCppLocale);
       return result;
   }

--- a/Modules/DiffusionImaging/DiffusionCore/autoload/IO/mitkDiffusionImageNiftiReaderService.cpp
+++ b/Modules/DiffusionImaging/DiffusionCore/autoload/IO/mitkDiffusionImageNiftiReaderService.cpp
@@ -43,6 +43,7 @@ See LICENSE.txt or http://www.mitk.org for details.
 #include <mitkITKImageImport.h>
 #include <mitkImageWriteAccessor.h>
 #include <mitkImageDataItem.h>
+#include <mitkLocaleSwitch.h>
 #include "mitkIOUtil.h"
 
 
@@ -104,21 +105,7 @@ void DiffusionImageNiftiReaderService::InternalRead()
   {
     try
     {
-      const std::string& locale = "C";
-      const std::string& currLocale = setlocale( LC_ALL, NULL );
-
-      if ( locale.compare(currLocale)!=0 )
-      {
-        try
-        {
-          setlocale(LC_ALL, locale.c_str());
-        }
-        catch(...)
-        {
-          MITK_INFO << "Could not set locale " << locale;
-        }
-      }
-
+      mitk::LocaleSwitch localeSwitch("C");
 
       MITK_INFO << "DiffusionImageNiftiReaderService: reading image information";
       VectorImageType::Pointer itkVectorImage;
@@ -443,15 +430,6 @@ void DiffusionImageNiftiReaderService::InternalRead()
       // so that it can be assigned to the DataObject in GenerateData();
       m_OutputCache = outputForCache;
       m_CacheTime.Modified();
-
-      try
-      {
-        setlocale(LC_ALL, currLocale.c_str());
-      }
-      catch(...)
-      {
-        MITK_INFO << "Could not reset locale " << currLocale;
-      }
     }
     catch(std::exception& e)
     {

--- a/Modules/DiffusionImaging/DiffusionCore/autoload/IO/mitkDiffusionImageNiftiWriterService.cpp
+++ b/Modules/DiffusionImaging/DiffusionCore/autoload/IO/mitkDiffusionImageNiftiWriterService.cpp
@@ -25,6 +25,7 @@ See LICENSE.txt or http://www.mitk.org for details.
 #include "itksys/SystemTools.hxx"
 #include "mitkDiffusionCoreIOMimeTypes.h"
 #include "mitkImageCast.h"
+#include <mitkLocaleSwitch.h>
 
 #include <iostream>
 #include <fstream>
@@ -61,20 +62,7 @@ void mitk::DiffusionImageNiftiWriterService::Write()
     MITK_ERROR << "Sorry, filename has not been set!";
     return ;
   }
-  const std::string& locale = "C";
-  const std::string& currLocale = setlocale( LC_ALL, NULL );
-
-  if ( locale.compare(currLocale)!=0 )
-  {
-    try
-    {
-      setlocale(LC_ALL, locale.c_str());
-    }
-    catch(...)
-    {
-      MITK_INFO << "Could not set locale " << locale;
-    }
-  }
+  mitk::LocaleSwitch localeSwitch("C");
 
   char keybuffer[512];
   char valbuffer[512];
@@ -409,14 +397,6 @@ void mitk::DiffusionImageNiftiWriterService::Write()
         myfile3 << std::endl;
       }
     }
-  }
-  try
-  {
-    setlocale(LC_ALL, currLocale.c_str());
-  }
-  catch(...)
-  {
-    MITK_INFO << "Could not reset locale " << currLocale;
   }
 }
 

--- a/Modules/DiffusionImaging/DiffusionCore/autoload/IO/mitkDiffusionImageNrrdReaderService.cpp
+++ b/Modules/DiffusionImaging/DiffusionCore/autoload/IO/mitkDiffusionImageNrrdReaderService.cpp
@@ -44,7 +44,7 @@ See LICENSE.txt or http://www.mitk.org for details.
 #include <mitkImageWriteAccessor.h>
 #include <mitkImageDataItem.h>
 #include "mitkIOUtil.h"
-
+#include <mitkLocaleSwitch.h>
 
 namespace mitk
 {
@@ -104,21 +104,7 @@ namespace mitk
     {
       try
       {
-        const std::string& locale = "C";
-        const std::string& currLocale = setlocale( LC_ALL, NULL );
-
-        if ( locale.compare(currLocale)!=0 )
-        {
-          try
-          {
-            setlocale(LC_ALL, locale.c_str());
-          }
-          catch(...)
-          {
-            MITK_INFO << "Could not set locale " << locale;
-          }
-        }
-
+        mitk::LocaleSwitch localeSwitch("C");
 
         MITK_INFO << "DiffusionImageNrrdReaderService: reading image information";
         VectorImageType::Pointer itkVectorImage;
@@ -240,14 +226,6 @@ namespace mitk
         m_OutputCache = outputForCache;
         m_CacheTime.Modified();
 
-        try
-        {
-          setlocale(LC_ALL, currLocale.c_str());
-        }
-        catch(...)
-        {
-          MITK_INFO << "Could not reset locale " << currLocale;
-        }
       }
       catch(std::exception& e)
       {

--- a/Modules/DiffusionImaging/DiffusionCore/autoload/IO/mitkDiffusionImageNrrdWriterService.cpp
+++ b/Modules/DiffusionImaging/DiffusionCore/autoload/IO/mitkDiffusionImageNrrdWriterService.cpp
@@ -25,6 +25,7 @@ See LICENSE.txt or http://www.mitk.org for details.
 #include "itksys/SystemTools.hxx"
 #include "mitkDiffusionCoreIOMimeTypes.h"
 #include "mitkImageCast.h"
+#include <mitkLocaleSwitch.h>
 
 #include <iostream>
 #include <fstream>
@@ -61,20 +62,7 @@ void mitk::DiffusionImageNrrdWriterService::Write()
     MITK_ERROR << "Sorry, filename has not been set!";
     return ;
   }
-  const std::string& locale = "C";
-  const std::string& currLocale = setlocale( LC_ALL, NULL );
-
-  if ( locale.compare(currLocale)!=0 )
-  {
-    try
-    {
-      setlocale(LC_ALL, locale.c_str());
-    }
-    catch(...)
-    {
-      MITK_INFO << "Could not set locale " << locale;
-    }
-  }
+  mitk::LocaleSwitch localeSwitch("C");
 
   char keybuffer[512];
   char valbuffer[512];
@@ -152,15 +140,6 @@ void mitk::DiffusionImageNrrdWriterService::Write()
       throw;
     }
 
-  }
-
-  try
-  {
-    setlocale(LC_ALL, currLocale.c_str());
-  }
-  catch(...)
-  {
-    MITK_INFO << "Could not reset locale " << currLocale;
   }
 }
 

--- a/Modules/DiffusionImaging/DiffusionCore/autoload/IO/mitkNrrdQBallImageReader.cpp
+++ b/Modules/DiffusionImaging/DiffusionCore/autoload/IO/mitkNrrdQBallImageReader.cpp
@@ -24,6 +24,7 @@ See LICENSE.txt or http://www.mitk.org for details.
 #include "itkNrrdImageIO.h"
 #include "mitkITKImageImport.h"
 #include "mitkImageDataItem.h"
+#include <mitkLocaleSwitch.h>
 
 namespace mitk
 {
@@ -55,20 +56,7 @@ namespace mitk
     {
       try
       {
-        const std::string& locale = "C";
-        const std::string& currLocale = setlocale( LC_ALL, NULL );
-
-        if ( locale.compare(currLocale)!=0 )
-        {
-          try
-          {
-            setlocale(LC_ALL, locale.c_str());
-          }
-          catch(...)
-          {
-            MITK_INFO << "Could not set locale " << locale;
-          }
-        }
+        mitk::LocaleSwitch localeSwitch("C");
 
         typedef itk::VectorImage<float,3> ImageType;
         itk::NrrdImageIO::Pointer io = itk::NrrdImageIO::New();
@@ -109,14 +97,6 @@ namespace mitk
         resultImage->SetVolume( vecImg->GetBufferPointer() );
         result.push_back( resultImage.GetPointer() );
 
-        try
-        {
-          setlocale(LC_ALL, currLocale.c_str());
-        }
-        catch(...)
-        {
-          MITK_INFO << "Could not reset locale " << currLocale;
-        }
       }
       catch(std::exception& e)
       {

--- a/Modules/DiffusionImaging/DiffusionCore/autoload/IO/mitkNrrdQBallImageWriter.cpp
+++ b/Modules/DiffusionImaging/DiffusionCore/autoload/IO/mitkNrrdQBallImageWriter.cpp
@@ -22,6 +22,7 @@ See LICENSE.txt or http://www.mitk.org for details.
 #include "mitkImageCast.h"
 #include "mitkIOMimeTypes.h"
 #include "mitkDiffusionCoreIOMimeTypes.h"
+#include <mitkLocaleSwitch.h>
 
 
 mitk::NrrdQBallImageWriter::NrrdQBallImageWriter()
@@ -53,19 +54,7 @@ void mitk::NrrdQBallImageWriter::Write()
         return ;
     }
 
-    const std::string& locale = "C";
-    const std::string& currLocale = setlocale( LC_ALL, NULL );
-    if ( locale.compare(currLocale)!=0 )
-    {
-      try
-      {
-        setlocale(LC_ALL, locale.c_str());
-      }
-      catch(...)
-      {
-        MITK_INFO << "Could not set locale " << locale;
-      }
-    }
+    mitk::LocaleSwitch localeSwitch("C");
 
     itk::NrrdImageIO::Pointer io = itk::NrrdImageIO::New();
     io->SetFileType( itk::ImageIOBase::Binary );
@@ -118,15 +107,6 @@ void mitk::NrrdQBallImageWriter::Write()
     catch (itk::ExceptionObject e)
     {
       std::cout << e << std::endl;
-    }
-
-    try
-    {
-      setlocale(LC_ALL, currLocale.c_str());
-    }
-    catch(...)
-    {
-      MITK_INFO << "Could not reset locale " << currLocale;
     }
 }
 

--- a/Modules/DiffusionImaging/DiffusionCore/autoload/IO/mitkNrrdTensorImageReader.cpp
+++ b/Modules/DiffusionImaging/DiffusionCore/autoload/IO/mitkNrrdTensorImageReader.cpp
@@ -26,6 +26,7 @@ See LICENSE.txt or http://www.mitk.org for details.
 
 #include "mitkITKImageImport.h"
 #include "mitkImageDataItem.h"
+#include <mitkLocaleSwitch.h>
 
 namespace mitk
 {
@@ -58,20 +59,7 @@ namespace mitk
     {
       try
       {
-        const std::string& locale = "C";
-        const std::string& currLocale = setlocale( LC_ALL, NULL );
-
-        if ( locale.compare(currLocale)!=0 )
-        {
-          try
-          {
-            setlocale(LC_ALL, locale.c_str());
-          }
-          catch(...)
-          {
-            MITK_INFO << "Could not set locale " << locale;
-          }
-        }
+        mitk::LocaleSwitch localeSwitch("C");
 
         try
         {
@@ -391,15 +379,6 @@ namespace mitk
           resultImage->InitializeByItk( vecImg.GetPointer() );
           resultImage->SetVolume( vecImg->GetBufferPointer() );
           result.push_back( resultImage.GetPointer() );
-        }
-
-        try
-        {
-          setlocale(LC_ALL, currLocale.c_str());
-        }
-        catch(...)
-        {
-          MITK_INFO << "Could not reset locale " << currLocale;
         }
 
       }

--- a/Modules/DiffusionImaging/DiffusionCore/autoload/IO/mitkNrrdTensorImageWriter.cpp
+++ b/Modules/DiffusionImaging/DiffusionCore/autoload/IO/mitkNrrdTensorImageWriter.cpp
@@ -22,6 +22,7 @@ See LICENSE.txt or http://www.mitk.org for details.
 #include "itkDiffusionTensor3D.h"
 #include "mitkImageCast.h"
 #include "mitkDiffusionCoreIOMimeTypes.h"
+#include <mitkLocaleSwitch.h>
 
 
 mitk::NrrdTensorImageWriter::NrrdTensorImageWriter()
@@ -53,19 +54,7 @@ void mitk::NrrdTensorImageWriter::Write()
     MITK_ERROR << "Sorry, filename has not been set!" ;
     return ;
   }
-  const std::string& locale = "C";
-  const std::string& currLocale = setlocale( LC_ALL, NULL );
-  if ( locale.compare(currLocale)!=0 )
-  {
-    try
-    {
-      setlocale(LC_ALL, locale.c_str());
-    }
-    catch(...)
-    {
-      MITK_INFO << "Could not set locale " << locale;
-    }
-  }
+  mitk::LocaleSwitch localeSwitch("C");
 
   itk::NrrdImageIO::Pointer io = itk::NrrdImageIO::New();
   io->SetFileType( itk::ImageIOBase::Binary );
@@ -91,16 +80,6 @@ void mitk::NrrdTensorImageWriter::Write()
   {
     std::cout << e << std::endl;
   }
-
-  try
-  {
-    setlocale(LC_ALL, currLocale.c_str());
-  }
-  catch(...)
-  {
-    MITK_INFO << "Could not reset locale " << currLocale;
-  }
-
 }
 
 mitk::NrrdTensorImageWriter* mitk::NrrdTensorImageWriter::Clone() const

--- a/Modules/DiffusionImaging/DiffusionCore/src/DicomImport/mitkDicomDiffusionImageHeaderReader.cpp
+++ b/Modules/DiffusionImaging/DiffusionCore/src/DicomImport/mitkDicomDiffusionImageHeaderReader.cpp
@@ -14,8 +14,9 @@ See LICENSE.txt or http://www.mitk.org for details.
 
 ===================================================================*/
 
-
 #include "mitkDicomDiffusionImageHeaderReader.h"
+
+#include <mitkLocaleSwitch.h>
 
 #include "mitkGEDicomDiffusionImageHeaderReader.h"
 #include "mitkPhilipsDicomDiffusionImageHeaderReader.h"
@@ -203,20 +204,7 @@ mitk::DicomDiffusionImageHeaderReader::GetOutput()
 
 void mitk::DicomDiffusionImageHeaderReader::ReadPublicTags()
 {
-  const std::string& locale = "C";
-  const std::string& currLocale = setlocale( LC_ALL, nullptr );
-
-  if ( locale.compare(currLocale)!=0 )
-  {
-    try
-    {
-      setlocale(LC_ALL, locale.c_str());
-    }
-    catch(...)
-    {
-      MITK_INFO << "Could not set locale " << locale;
-    }
-  }
+  mitk::LocaleSwitch localeSwitch("C");
 
   VolumeReaderType::DictionaryArrayRawPointer inputDict
     = m_VolumeReader->GetMetaDataDictionaryArray();
@@ -314,15 +302,6 @@ void mitk::DicomDiffusionImageHeaderReader::ReadPublicTags()
   this->m_Output->xSlice = xSlice;
   this->m_Output->ySlice = ySlice;
   this->m_Output->zSlice = zSlice;
-
-  try
-  {
-    setlocale(LC_ALL, currLocale.c_str());
-  }
-  catch(...)
-  {
-    MITK_INFO << "Could not reset locale " << currLocale;
-  }
 }
 
 

--- a/Modules/DiffusionImaging/DiffusionCore/src/DicomImport/mitkGEDicomDiffusionImageHeaderReader.cpp
+++ b/Modules/DiffusionImaging/DiffusionCore/src/DicomImport/mitkGEDicomDiffusionImageHeaderReader.cpp
@@ -14,8 +14,10 @@ See LICENSE.txt or http://www.mitk.org for details.
 
 ===================================================================*/
 
-
 #include "mitkGEDicomDiffusionImageHeaderReader.h"
+
+#include <mitkLocaleSwitch.h>
+
 
 #include "gdcmGlobal.h"
 #include "gdcmDict.h"
@@ -42,20 +44,7 @@ void mitk::GEDicomDiffusionImageHeaderReader::Update()
   // check if there are filenames
   if(m_DicomFilenames.size())
   {
-    const std::string& locale = "C";
-    const std::string& currLocale = setlocale( LC_ALL, nullptr );
-
-    if ( locale.compare(currLocale)!=0 )
-    {
-      try
-      {
-        setlocale(LC_ALL, locale.c_str());
-      }
-      catch(...)
-      {
-        MITK_INFO << "Could not set locale " << locale;
-      }
-    }
+    mitk::LocaleSwitch localeSwitch("C");
 
     // adapted from namic-sandbox
     // DicomToNrrdConverter.cxx
@@ -132,15 +121,6 @@ void mitk::GEDicomDiffusionImageHeaderReader::Update()
     }
 
     TransformGradients();
-
-    try
-    {
-      setlocale(LC_ALL, currLocale.c_str());
-    }
-    catch(...)
-    {
-      MITK_INFO << "Could not reset locale " << currLocale;
-    }
   }
 }
 

--- a/Modules/DiffusionImaging/DiffusionCore/src/DicomImport/mitkSiemensDicomDiffusionImageHeaderReader.cpp
+++ b/Modules/DiffusionImaging/DiffusionCore/src/DicomImport/mitkSiemensDicomDiffusionImageHeaderReader.cpp
@@ -14,8 +14,11 @@ See LICENSE.txt or http://www.mitk.org for details.
 
 ===================================================================*/
 
-
 #include "mitkSiemensDicomDiffusionImageHeaderReader.h"
+
+#include <mitkLocaleSwitch.h>
+
+
 #include "gdcmGlobal.h"
 //#include <gdcmVersion.h>
 
@@ -83,20 +86,7 @@ void mitk::SiemensDicomDiffusionImageHeaderReader::Update()
   // check if there are filenames
   if(m_DicomFilenames.size())
   {
-    const std::string& locale = "C";
-    const std::string& currLocale = setlocale( LC_ALL, nullptr );
-
-    if ( locale.compare(currLocale)!=0 )
-    {
-      try
-      {
-        setlocale(LC_ALL, locale.c_str());
-      }
-      catch(...)
-      {
-        MITK_INFO << "Could not set locale " << locale;
-      }
-    }
+    mitk::LocaleSwitch localeSwitch("C");
 
     // adapted from slicer
     // DicomToNrrdConverter.cxx
@@ -251,14 +241,6 @@ void mitk::SiemensDicomDiffusionImageHeaderReader::Update()
       vect3d.fill( 0.0 );
       this->m_Output->DiffusionVector = vect3d;
 
-    }
-    try
-    {
-      setlocale(LC_ALL, currLocale.c_str());
-    }
-    catch(...)
-    {
-      MITK_INFO << "Could not reset locale " << currLocale;
     }
   }
 }

--- a/Modules/IGTBase/autoload/IO/mitkNavigationDataReaderCSV.cpp
+++ b/Modules/IGTBase/autoload/IO/mitkNavigationDataReaderCSV.cpp
@@ -17,6 +17,7 @@ See LICENSE.txt or http://www.mitk.org for details.
 // MITK
 #include "mitkNavigationDataReaderCSV.h"
 #include <mitkIGTMimeTypes.h>
+#include <mitkLocaleSwitch.h>
 
 // STL
 #include <fstream>
@@ -147,13 +148,8 @@ std::vector<std::string> mitk::NavigationDataReaderCSV::GetFileContentLineByLine
 {
 std::vector<std::string> readData = std::vector<std::string>();
 
-//save old locale
-char * oldLocale;
-oldLocale = setlocale( LC_ALL, nullptr );
-
 //define own locale
-std::locale C("C");
-setlocale( LC_ALL, "C" );
+mitk::LocaleSwitch localeSwitch("C");
 
 //read file
 std::ifstream file;
@@ -172,9 +168,6 @@ if (file.good())
     }
 
 file.close();
-
-//switch back to old locale
-setlocale( LC_ALL, oldLocale );
 
 return readData;
 }

--- a/Modules/IGTBase/autoload/IO/mitkNavigationDataReaderXML.cpp
+++ b/Modules/IGTBase/autoload/IO/mitkNavigationDataReaderXML.cpp
@@ -17,6 +17,7 @@ See LICENSE.txt or http://www.mitk.org for details.
 // MITK
 #include "mitkNavigationDataReaderXML.h"
 #include <mitkIGTMimeTypes.h>
+#include <mitkLocaleSwitch.h>
 
 // Third Party
 #include <itksys/SystemTools.hxx>
@@ -65,13 +66,8 @@ std::vector<itk::SmartPointer<mitk::BaseData>> mitk::NavigationDataReaderXML::Re
 
 mitk::NavigationDataSet::Pointer mitk::NavigationDataReaderXML::Read(std::string fileName)
 {
-  //save old locale
-  char * oldLocale;
-  oldLocale = setlocale(LC_ALL, 0);
-
   //define own locale
-  std::locale C("C");
-  setlocale(LC_ALL, "C");
+  mitk::LocaleSwitch localeSwitch("C");
 
   m_FileName = fileName;
 
@@ -116,21 +112,13 @@ mitk::NavigationDataSet::Pointer mitk::NavigationDataReaderXML::Read(std::string
 
   mitk::NavigationDataSet::Pointer navigationDataSet = this->ReadNavigationDataSet();
 
-  //switch back to old locale
-  setlocale(LC_ALL, oldLocale);
-
   return navigationDataSet;
 }
 
 mitk::NavigationDataSet::Pointer mitk::NavigationDataReaderXML::Read(std::istream* stream)
 {
-  //save old locale
-  char * oldLocale;
-  oldLocale = setlocale( LC_ALL, nullptr );
-
   //define own locale
-  std::locale C("C");
-  setlocale( LC_ALL, "C" );
+  mitk::LocaleSwitch localeSwitch("C");
 
   // first get the file version
   m_FileVersion = this->GetFileVersion(stream);
@@ -146,9 +134,6 @@ mitk::NavigationDataSet::Pointer mitk::NavigationDataReaderXML::Read(std::istrea
   if (m_NumberOfOutputs == 0) { return nullptr; }
 
   mitk::NavigationDataSet::Pointer dataSet = this->ReadNavigationDataSet();
-
-  //switch back to old locale
-  setlocale( LC_ALL, oldLocale );
 
   return dataSet;
 }

--- a/Modules/IGTBase/autoload/IO/mitkNavigationDataSetWriterCSV.cpp
+++ b/Modules/IGTBase/autoload/IO/mitkNavigationDataSetWriterCSV.cpp
@@ -17,6 +17,7 @@ See LICENSE.txt or http://www.mitk.org for details.
 #include "mitkNavigationDataSetWriterCSV.h"
 #include <fstream>
 #include <mitkIGTMimeTypes.h>
+#include <mitkLocaleSwitch.h>
 
 mitk::NavigationDataSetWriterCSV::NavigationDataSetWriterCSV() : AbstractFileWriter(NavigationDataSet::GetStaticNameOfClass(),
   mitk::IGTMimeTypes::NAVIGATIONDATASETCSV_MIMETYPE(),
@@ -46,13 +47,8 @@ void mitk::NavigationDataSetWriterCSV::Write()
   }
   mitk::NavigationDataSet::ConstPointer data = dynamic_cast<const NavigationDataSet*> (this->GetInput());
 
-    //save old locale
-  char * oldLocale;
-  oldLocale = setlocale( LC_ALL, nullptr );
-
   //define own locale
-  std::locale C("C");
-  setlocale( LC_ALL, "C" );
+  mitk::LocaleSwitch localeSwitch("C");
 
   //write header
   unsigned int numberOfTools = data->GetNumberOfTools();
@@ -92,6 +88,4 @@ void mitk::NavigationDataSetWriterCSV::Write()
 
   out->flush();
   delete out;
-  //switch back to old locale
-  setlocale( LC_ALL, oldLocale );
 }

--- a/Modules/IGTBase/autoload/IO/mitkNavigationDataSetWriterXML.cpp
+++ b/Modules/IGTBase/autoload/IO/mitkNavigationDataSetWriterXML.cpp
@@ -17,6 +17,7 @@ See LICENSE.txt or http://www.mitk.org for details.
 // MITK
 #include "mitkNavigationDataSetWriterXML.h"
 #include <mitkIGTMimeTypes.h>
+#include <mitkLocaleSwitch.h>
 
 // Third Party
 #include <tinyxml.h>
@@ -53,9 +54,7 @@ void mitk::NavigationDataSetWriterXML::Write()
   }
   mitk::NavigationDataSet::ConstPointer data = dynamic_cast<const NavigationDataSet*> (this->GetInput());
 
-  //save old locale
-  char * oldLocale;
-  oldLocale = setlocale( LC_ALL, nullptr );
+  mitk::LocaleSwitch localeSwitch("C");
 
   StreamHeader(out, data);
   StreamData(out, data);
@@ -64,9 +63,6 @@ void mitk::NavigationDataSetWriterXML::Write()
   // Cleanup
   out->flush();
   delete out;
-
-  //switch back to old locale
-  setlocale( LC_ALL, oldLocale );
 }
 
 void mitk::NavigationDataSetWriterXML::StreamHeader (std::ostream* stream, mitk::NavigationDataSet::ConstPointer data)

--- a/Modules/IOExt/Internal/mitkParRecFileReader.cpp
+++ b/Modules/IOExt/Internal/mitkParRecFileReader.cpp
@@ -17,6 +17,7 @@ See LICENSE.txt or http://www.mitk.org for details.
 
 #include "mitkParRecFileReader.h"
 #include <itkImageFileReader.h>
+#include <mitkLocaleSwitch.h>
 
 #ifdef __GNUC__
 #define stricmp strcasecmp
@@ -114,25 +115,22 @@ void mitk::ParRecFileReader::GenerateOutputInformation()
         if(strstr(s,"FOV (ap,fh,rl) [mm]"))
         {
           p=s+strcspn(s,"0123456789");
-          char *oldLocale = setlocale(LC_ALL, nullptr);
+          mitk::LocaleSwitch localeSwitch("C");
           sscanf(p,"%lf %lf %lf", &thickness[0], &thickness[1], &thickness[2]);
-          setlocale(LC_ALL, oldLocale);
         }
         else
         if(strstr(s,"Slice thickness [mm]"))
         {
           p=s+strcspn(s,"0123456789");
-          char *oldLocale = setlocale(LC_ALL, nullptr);
+          mitk::LocaleSwitch localeSwitch("C");
           sscanf(p,"%f", &sliceThickness);
-          setlocale(LC_ALL, oldLocale);
         }
         else
         if(strstr(s,"Slice gap [mm]"))
         {
           p=s+strcspn(s,"-0123456789");
-          char *oldLocale = setlocale(LC_ALL, nullptr);
+          mitk::LocaleSwitch localeSwitch("C");
           sscanf(p,"%f", &sliceGap);
-          setlocale(LC_ALL, oldLocale);
         }
       }
       fclose(f);

--- a/Modules/LegacyIO/mitkDataNodeFactory.cpp
+++ b/Modules/LegacyIO/mitkDataNodeFactory.cpp
@@ -19,6 +19,7 @@ See LICENSE.txt or http://www.mitk.org for details.
 #include <mitkBaseDataIOFactory.h>
 #include <mitkCoreObjectFactory.h>
 #include <mitkITKImageImport.h>
+#include <mitkLocaleSwitch.h>
 
 // C-Standard library includes
 #include <stdlib.h>
@@ -229,8 +230,7 @@ std::string mitk::DataNodeFactory::GetDirectory()
 
 void mitk::DataNodeFactory::ReadFileSeriesTypeDCM()
 {
-  const char* previousCLocale = setlocale(LC_NUMERIC, NULL);
-  setlocale(LC_NUMERIC, "C");
+  mitk::LocaleSwitch localeSwitch("C");
   std::locale previousCppLocale( std::cin.getloc() );
   std::locale l( "C" );
   std::cin.imbue(l);
@@ -246,7 +246,6 @@ void mitk::DataNodeFactory::ReadFileSeriesTypeDCM()
     {
       node->SetName(this->GetBaseFileName());
     }
-    setlocale(LC_NUMERIC, previousCLocale);
     std::cin.imbue(previousCppLocale);
     return;
 
@@ -305,7 +304,6 @@ void mitk::DataNodeFactory::ReadFileSeriesTypeDCM()
     ProgressBar::GetInstance()->Progress();
   }
 
-  setlocale(LC_NUMERIC, previousCLocale);
   std::cin.imbue(previousCppLocale);
 }
 

--- a/Modules/LegacyIO/mitkImageWriter.cpp
+++ b/Modules/LegacyIO/mitkImageWriter.cpp
@@ -21,6 +21,7 @@ See LICENSE.txt or http://www.mitk.org for details.
 #include "mitkImageTimeSelector.h"
 #include "mitkImageAccessByItk.h"
 #include "mitkImageReadAccessor.h"
+#include <mitkLocaleSwitch.h>
 
 #include <itkImageIOBase.h>
 #include <itkImageIOFactory.h>
@@ -232,20 +233,7 @@ void mitk::ImageWriter::WriteByITK(mitk::Image* image, const std::string& fileNa
 
 void mitk::ImageWriter::GenerateData()
 {
-   const std::string& locale = "C";
-   const std::string& currLocale = setlocale( LC_ALL, nullptr );
-
-   if ( locale.compare(currLocale)!=0 )
-   {
-      try
-      {
-         setlocale(LC_ALL, locale.c_str());
-      }
-      catch(...)
-      {
-         MITK_INFO << "Could not set locale " << locale;
-      }
-   }
+   mitk::LocaleSwitch localeSwitch("C");
 
    if ( m_FileName == "" )
    {
@@ -367,15 +355,6 @@ void mitk::ImageWriter::GenerateData()
       }
    }
    m_MimeType = "application/MITK.Pic";
-
-   try
-   {
-      setlocale(LC_ALL, currLocale.c_str());
-   }
-   catch(...)
-   {
-      MITK_INFO << "Could not reset locale " << currLocale;
-   }
 }
 
 bool mitk::ImageWriter::CanWriteDataType( DataNode* input )

--- a/Modules/LegacyIO/mitkItkImageFileReader.cpp
+++ b/Modules/LegacyIO/mitkItkImageFileReader.cpp
@@ -19,6 +19,7 @@ See LICENSE.txt or http://www.mitk.org for details.
 #include "mitkConfig.h"
 #include "mitkException.h"
 #include <mitkProportionalTimeGeometry.h>
+#include <mitkLocaleSwitch.h>
 
 #include <itkImageFileReader.h>
 #include <itksys/SystemTools.hxx>
@@ -39,21 +40,7 @@ See LICENSE.txt or http://www.mitk.org for details.
 
 void mitk::ItkImageFileReader::GenerateData()
 {
-  const std::string& locale = "C";
-  const std::string& currLocale = setlocale( LC_ALL, nullptr );
-
-  if ( locale.compare(currLocale)!=0 )
-  {
-    try
-    {
-      setlocale(LC_ALL, locale.c_str());
-    }
-    catch(...)
-    {
-      MITK_INFO("mitkItkImageFileReader") << "Could not set locale " << locale;
-    }
-  }
-
+  mitk::LocaleSwitch localeSwitch("C");
   mitk::Image::Pointer image = this->GetOutput();
 
   const unsigned int MINDIM = 2;
@@ -173,15 +160,6 @@ void mitk::ItkImageFileReader::GenerateData()
   //  SetDefaultImageProperties( node );
   //}
   MITK_INFO("mitkItkImageFileReader") << "...finished!" << std::endl;
-
-  try
-  {
-    setlocale(LC_ALL, currLocale.c_str());
-  }
-  catch(...)
-  {
-    MITK_INFO("mitkItkImageFileReader") << "Could not reset locale " << currLocale;
-  }
 }
 
 

--- a/Modules/PlanarFigure/src/IO/mitkPlanarFigureReader.cpp
+++ b/Modules/PlanarFigure/src/IO/mitkPlanarFigureReader.cpp
@@ -32,6 +32,7 @@ See LICENSE.txt or http://www.mitk.org for details.
 #include "mitkPlanarBezierCurve.h"
 
 #include "mitkBasePropertySerializer.h"
+#include <mitkLocaleSwitch.h>
 
 #include <tinyxml.h>
 #include <itksys/SystemTools.hxx>
@@ -59,21 +60,7 @@ mitk::PlanarFigureReader::~PlanarFigureReader()
 
 void mitk::PlanarFigureReader::GenerateData()
 {
-    const std::string& locale = "C";
-    const std::string& currLocale = setlocale( LC_ALL, nullptr );
-
-    if ( locale.compare(currLocale)!=0 )
-    {
-      try
-      {
-        setlocale(LC_ALL, locale.c_str());
-      }
-      catch(...)
-      {
-        MITK_INFO << "Could not set locale " << locale;
-      }
-    }
-
+  mitk::LocaleSwitch localeSwitch("C");
   m_Success = false;
   this->SetNumberOfIndexedOutputs(0); // reset all outputs, we add new ones depending on the file content
 
@@ -366,15 +353,6 @@ void mitk::PlanarFigureReader::GenerateData()
 
     // \TODO: what about m_FigurePlaced and m_SelectedControlPoint ??
     this->SetNthOutput( this->GetNumberOfOutputs(), planarFigure );  // add planarFigure as new output of this filter
-  }
-
-  try
-  {
-    setlocale(LC_ALL, currLocale.c_str());
-  }
-  catch(...)
-  {
-    MITK_INFO << "Could not reset locale " << currLocale;
   }
 
   m_Success = true;

--- a/Plugins/org.mitk.gui.qt.dicom/src/internal/DicomEventHandler.cpp
+++ b/Plugins/org.mitk.gui.qt.dicom/src/internal/DicomEventHandler.cpp
@@ -49,6 +49,7 @@ See LICENSE.txt or http://www.mitk.org for details.
 #include <mitkTransferFunction.h>
 #include <mitkTransferFunctionProperty.h>
 #include <mitkRenderingModeProperty.h>
+#include <mitkLocaleSwitch.h>
 
 #include <berryIPreferencesService.h>
 #include <berryIPreferences.h>
@@ -269,8 +270,7 @@ void DicomEventHandler::OnSignalAddSeriesToDataManager(const ctkEvent& ctkEvent)
       if (!seriesToLoad.empty() && mitk::DicomSeriesReader::IsPhilips3DDicom(seriesToLoad.front()))
       {
           MITK_INFO << "it is a Philips3D US Dicom file" << std::endl;
-          const char* previousCLocale = setlocale(LC_NUMERIC, NULL);
-          setlocale(LC_NUMERIC, "C");
+          mitk::LocaleSwitch localeSwitch("C");
           std::locale previousCppLocale(std::cin.getloc());
           std::locale l("C");
           std::cin.imbue(l);
@@ -286,7 +286,6 @@ void DicomEventHandler::OnSignalAddSeriesToDataManager(const ctkEvent& ctkEvent)
               node->SetProperty("name", nameProp);
               dataStorage->Add(node);
           }
-          setlocale(LC_NUMERIC, previousCLocale);
           std::cin.imbue(previousCppLocale);
           return;
       }


### PR DESCRIPTION
Calls like 
```
  const char* previousCLocale = setlocale(LC_NUMERIC, nullptr);
  setlocale(LC_NUMERIC, "C");
```
are invalid because `previousCLocale` variable becomes invalid after the second `setlocale() `call.

https://msdn.microsoft.com/ru-ru/library/x99tb11d.aspx:
"Later calls to setlocale overwrite the string, which invalidates string pointers returned by earlier calls."

This may lead to random crashes.
It's possible to reproduce such crash if run debug version of program under Application Verifier with Basics.Heaps option enabled.

Signed-off-by: KuznetsovAlexander <KuznetsovAlexander@rambler.ru>