### PR TITLE
Bug 17812 sliced geometry init

### DIFF
--- a/Modules/Core/include/mitkArbitraryTimeGeometry.h
+++ b/Modules/Core/include/mitkArbitraryTimeGeometry.h
@@ -62,14 +62,14 @@ namespace mitk {
     * is also the upper bound of the time steps. The
     * minimum time steps is always 0.
     */
-    virtual TimeStepType     CountTimeSteps() const;
+    virtual TimeStepType     CountTimeSteps() const override;
     /**
     * \brief Returns the first time point for which the time geometry instance is valid.
     *
     * Returns the first valid time point for this geometry. It is the lower time bound of
     * the first step. The time point is given in ms.
     */
-    virtual TimePointType    GetMinimumTimePoint () const;
+    virtual TimePointType    GetMinimumTimePoint () const override;
     /**
     * \brief Returns the last time point for which the time geometry instance is valid
     *
@@ -77,7 +77,7 @@ namespace mitk {
     * this time geometry. It is the upper time bound of the last step.
     * The time point is given in ms.
     */
-    virtual TimePointType    GetMaximumTimePoint () const;
+    virtual TimePointType    GetMaximumTimePoint () const override;
 
     /**
     * \brief Returns the first time point for which the time geometry instance is valid.
@@ -85,24 +85,24 @@ namespace mitk {
     * Returns the first valid time point for the given TimeStep. The time point
     * is given in ms.
     */
-    virtual TimePointType    GetMinimumTimePoint(TimeStepType step) const;
+    virtual TimePointType    GetMinimumTimePoint(TimeStepType step) const override;
     /**
     * \brief Returns the last time point for which the time geometry instance is valid
     *
     * Gives the last time point for the Geometry specified by the given TimeStep. The time point is given in ms.
     */
-    virtual TimePointType    GetMaximumTimePoint(TimeStepType step) const;
+    virtual TimePointType    GetMaximumTimePoint(TimeStepType step) const override;
 
     /**
     * \brief Get the time bounds (in ms)
     * it returns GetMinimumTimePoint() and GetMaximumTimePoint() results as bounds.
     */
-    virtual TimeBounds GetTimeBounds( ) const;
+    virtual TimeBounds GetTimeBounds( ) const override;
 
     /**
     * \brief Get the time bounds for the given TimeStep (in ms)
     */
-    virtual TimeBounds GetTimeBounds(TimeStepType step) const;
+    virtual TimeBounds GetTimeBounds(TimeStepType step) const override;
 
     /**
     * \brief Tests if a given time point is covered by this time geometry instance
@@ -111,7 +111,7 @@ namespace mitk {
     * point (so it is within GetTimeBounds() and fails if not.
     * The time point must be given in ms.
     */
-    virtual bool IsValidTimePoint (TimePointType timePoint) const;
+    virtual bool IsValidTimePoint (TimePointType timePoint) const override;
     /**
     * \brief Test for the given time step if a geometry is availible
     *
@@ -119,7 +119,7 @@ namespace mitk {
     * Otherwise false is returned.
     * The time step is defined as positiv number.
     */
-    virtual bool IsValidTimeStep  (TimeStepType timeStep) const;
+    virtual bool IsValidTimeStep  (TimeStepType timeStep) const override;
     /**
     * \brief Converts a time step to a time point
     *
@@ -129,7 +129,7 @@ namespace mitk {
     * a time point is calculated that also does not point to a valid
     * geometry, but no exception is raised.
     */
-    virtual TimePointType  TimeStepToTimePoint (TimeStepType timeStep) const;
+    virtual TimePointType  TimeStepToTimePoint (TimeStepType timeStep) const override;
         /**
     * \brief Converts a time point to the corresponding time step
     *
@@ -141,14 +141,14 @@ namespace mitk {
     * returned. If an positive invalid time step is given an invalid
     * time step will be returned.
     */
-    virtual TimeStepType   TimePointToTimeStep (TimePointType timePoint) const;
+    virtual TimeStepType   TimePointToTimeStep (TimePointType timePoint) const override;
     /**
     * \brief Returns the geometry which corresponds to the given time step
     *
     * Returns a clone of the geometry which defines the given time step. If
     * the given time step is invalid an null-pointer is returned.
     */
-    virtual BaseGeometry::Pointer GetGeometryCloneForTimeStep( TimeStepType timeStep) const;
+    virtual BaseGeometry::Pointer GetGeometryCloneForTimeStep( TimeStepType timeStep) const override;
 
     /**
     * \brief Returns the geometry which corresponds to the given time point
@@ -159,7 +159,7 @@ namespace mitk {
     * If the returned geometry is changed this will affect the saved
     * geometry.
     */
-    virtual BaseGeometry::Pointer GetGeometryForTimePoint ( TimePointType timePoint) const;
+    virtual BaseGeometry::Pointer GetGeometryForTimePoint ( TimePointType timePoint) const override;
     /**
     * \brief Returns the geometry which corresponds to the given time step
     *
@@ -169,17 +169,17 @@ namespace mitk {
     * If the returned geometry is changed this will affect the saved
     * geometry.
     */
-    virtual BaseGeometry::Pointer GetGeometryForTimeStep  ( TimeStepType timeStep) const;
+    virtual BaseGeometry::Pointer GetGeometryForTimeStep  ( TimeStepType timeStep) const override;
 
     /**
     * \brief Tests if all necessary informations are set and the object is valid
     */
-    virtual bool IsValid () const;
+    virtual bool IsValid () const override;
 
     /**
     * \brief Initializes a new object with one time steps which contains an empty geometry.
     */
-    virtual void Initialize();
+    virtual void Initialize() override;
 
     /**
     * \brief Expands the time geometry to the given number of time steps.
@@ -187,7 +187,7 @@ namespace mitk {
     * Initializes the new time steps with empty geometries. This default geometries will behave like ProportionalTimeGeometry.
     * Shrinking is not supported. The new steps will have the same duration like the last step before extension.
     */
-    virtual void Expand(TimeStepType size);
+    virtual void Expand(TimeStepType size) override;
 
     /**
     * \brief Replaces the geometry instances with clones of the passed geometry.
@@ -199,7 +199,7 @@ namespace mitk {
     * to change the spatial properties of a TimeGeometry and preserve the time
     * "grid".
     */
-    virtual void ReplaceTimeStepGeometries(const BaseGeometry* geometry);
+    virtual void ReplaceTimeStepGeometries(const BaseGeometry* geometry) override;
 
     /**
     * \brief Sets the geometry for the given time step
@@ -207,12 +207,12 @@ namespace mitk {
     * If passed time step is not valid. Nothing will be changed.
     * @pre geometry must point to a valid instance.
     */
-    virtual void SetTimeStepGeometry(BaseGeometry* geometry, TimeStepType timeStep);
+    virtual void SetTimeStepGeometry(BaseGeometry* geometry, TimeStepType timeStep) override;
 
     /**
     * \brief Makes a deep copy of the current object
     */
-    virtual itk::LightObject::Pointer InternalClone () const;
+    virtual itk::LightObject::Pointer InternalClone () const override;
 
     void ClearAllGeometries ();
 
@@ -227,7 +227,7 @@ namespace mitk {
 
     void ReserveSpaceForGeometries (TimeStepType numberOfGeometries);
 
-    virtual void PrintSelf(std::ostream& os, itk::Indent indent) const;
+    virtual void PrintSelf(std::ostream& os, itk::Indent indent) const override;
 
   protected:
     virtual ~ArbitraryTimeGeometry();

--- a/Modules/Core/include/mitkBaseRenderer.h
+++ b/Modules/Core/include/mitkBaseRenderer.h
@@ -113,7 +113,7 @@ namespace mitk
       Standard2D = 1, Standard3D = 2
     };
 
-    virtual void SetDataStorage(DataStorage* storage);  ///< set the datastorage that will be used for rendering
+    virtual void SetDataStorage(DataStorage* dataStorage);  ///< set the data storage that will be used for rendering
 
     //##Documentation
     //## return the DataStorage that is used for rendering

--- a/Modules/Core/include/mitkProportionalTimeGeometry.h
+++ b/Modules/Core/include/mitkProportionalTimeGeometry.h
@@ -198,7 +198,7 @@ namespace mitk {
     * to change the spatial properties of a TimeGeometry and preserve the time
     * "grid".
     */
-    virtual void ReplaceTimeStepGeometries(const BaseGeometry* geometry);
+    virtual void ReplaceTimeStepGeometries(const BaseGeometry* geometry) override;
 
     /**
     * \brief Makes a deep copy of the current object

--- a/Modules/Core/include/mitkVtkPropRenderer.h
+++ b/Modules/Core/include/mitkVtkPropRenderer.h
@@ -81,7 +81,7 @@ public:
   // Active current renderwindow
   virtual void MakeCurrent();
 
-  virtual void SetDataStorage( mitk::DataStorage* storage ) override;  ///< set the datastorage that will be used for rendering
+  virtual void SetDataStorage(mitk::DataStorage* dataStorage) override;  ///< set the data storage that will be used for rendering
 
   virtual void InitRenderer(vtkRenderWindow* renderwindow) override;
   virtual void Update(mitk::DataNode* datatreenode);

--- a/Modules/Core/src/DataManagement/mitkDataStorage.cpp
+++ b/Modules/Core/src/DataManagement/mitkDataStorage.cpp
@@ -372,11 +372,16 @@ mitk::TimeGeometry::Pointer mitk::DataStorage::ComputeBoundingGeometry3D( const 
     // correct bounding-box (is now in mm, should be in index-coordinates)
     // according to spacing
     BoundingBox::BoundsArrayType bounds = result->GetBounds();
-    int i;
-    for(i = 0; i < 6; ++i)
+    AffineTransform3D::OutputVectorType offset;
+    for (int i = 0; i < 3; ++i)
+    {
+      offset[i] = bounds[i * 2];
+    }
+    for (int i = 0; i < 6; ++i)
     {
       bounds[i] /= minSpacing[i/2];
     }
+    geometry->GetIndexToWorldTransform()->SetOffset(offset);
     geometry->SetBounds(bounds);
     geometry->SetSpacing(minSpacing);
     // Initialize the time sliced geometry

--- a/Modules/Core/src/DataManagement/mitkImage.cpp
+++ b/Modules/Core/src/DataManagement/mitkImage.cpp
@@ -820,11 +820,12 @@ void mitk::Image::Initialize(const mitk::PixelType& type, unsigned int dimension
     this->m_ImageDescriptor->AddNewChannel( type );
   }
 
-  PlaneGeometry::Pointer planegeometry = PlaneGeometry::New();
-  planegeometry->InitializeStandardPlane(m_Dimensions[0], m_Dimensions[1]);
+  PlaneGeometry::Pointer planeGeometry = PlaneGeometry::New();
+  planeGeometry->InitializeStandardPlane(m_Dimensions[0], m_Dimensions[1]);
+  planeGeometry->ImageGeometryOn();
 
   SlicedGeometry3D::Pointer slicedGeometry = SlicedGeometry3D::New();
-  slicedGeometry->InitializeEvenlySpaced(planegeometry, m_Dimensions[2]);
+  slicedGeometry->InitializeEvenlySpaced(planeGeometry, m_Dimensions[2]);
 
   ProportionalTimeGeometry::Pointer timeGeometry = ProportionalTimeGeometry::New();
   timeGeometry->Initialize(slicedGeometry, m_Dimensions[3]);

--- a/Modules/Core/src/Rendering/mitkBaseRenderer.cpp
+++ b/Modules/Core/src/Rendering/mitkBaseRenderer.cpp
@@ -257,11 +257,11 @@ void mitk::BaseRenderer::UnregisterLocalStorageHandler(mitk::BaseLocalStorageHan
   m_RegisteredLocalStorageHandlers.remove(lsh);
 }
 
-void mitk::BaseRenderer::SetDataStorage(DataStorage* storage)
+void mitk::BaseRenderer::SetDataStorage(DataStorage* dataStorage)
 {
-  if (storage != m_DataStorage && storage != nullptr )
+  if (dataStorage != m_DataStorage && dataStorage != nullptr)
   {
-    m_DataStorage = storage;
+    m_DataStorage = dataStorage;
     m_BindDispatcherInteractor->SetDataStorage(m_DataStorage);
     this->Modified();
   }

--- a/Modules/Core/src/Rendering/mitkVtkPropRenderer.cpp
+++ b/Modules/Core/src/Rendering/mitkVtkPropRenderer.cpp
@@ -119,17 +119,17 @@ mitk::VtkPropRenderer::~VtkPropRenderer()
     m_TextRenderer->Delete();
 }
 
-void mitk::VtkPropRenderer::SetDataStorage(mitk::DataStorage* storage)
+void mitk::VtkPropRenderer::SetDataStorage(mitk::DataStorage* dataStorage)
 {
-  if (storage == NULL)
-    return;
+  if (dataStorage != m_DataStorage && dataStorage != nullptr)
+  {
+    BaseRenderer::SetDataStorage(dataStorage);
 
-  BaseRenderer::SetDataStorage(storage);
+    static_cast<mitk::PlaneGeometryDataVtkMapper3D*>(m_CurrentWorldPlaneGeometryMapper.GetPointer())->SetDataStorageForTexture( m_DataStorage.GetPointer() );
 
-  static_cast<mitk::PlaneGeometryDataVtkMapper3D*>(m_CurrentWorldPlaneGeometryMapper.GetPointer())->SetDataStorageForTexture(m_DataStorage.GetPointer());
-
-  // Compute the geometry from the current data tree bounds and set it as world geometry
-  this->SetWorldGeometryToDataStorageBounds();
+    // Compute the geometry from the current data tree bounds and set it as world geometry
+    this->SetWorldGeometryToDataStorageBounds();
+  }
 }
 
 bool mitk::VtkPropRenderer::SetWorldGeometryToDataStorageBounds()

--- a/Modules/Core/test/mitkClippedSurfaceBoundsCalculatorTest.cpp
+++ b/Modules/Core/test/mitkClippedSurfaceBoundsCalculatorTest.cpp
@@ -426,6 +426,7 @@ static void CheckIntersectionWithRotatedGeometry()
   mitk::PlaneGeometry::Pointer planeGeometry3 = mitk::PlaneGeometry::New();
   planeGeometry3->InitializePlane(origin3, normal3);
   planeGeometry3->SetSpacing(spacing);
+  planeGeometry3->SetImageGeometry(true);
 
   mitk::BoundingBox::BoundsArrayType moreBounds = planeGeometry3->GetBounds();
   moreBounds[0] = 0;
@@ -769,6 +770,7 @@ int mitkClippedSurfaceBoundsCalculatorTest(int, char* [])
   //Initialize PlaneGeometry:
   mitk::PlaneGeometry::Pointer planeGeometry = mitk::PlaneGeometry::New();
   planeGeometry->InitializePlane(origin, normal);
+  planeGeometry->ImageGeometryOn();
 
   //Set Bounds:
   mitk::BoundingBox::BoundsArrayType bounds = planeGeometry->GetBounds();
@@ -784,7 +786,6 @@ int mitkClippedSurfaceBoundsCalculatorTest(int, char* [])
   mitk::SlicedGeometry3D::Pointer slicedGeometry3D = mitk::SlicedGeometry3D::New();
   slicedGeometry3D->InitializeEvenlySpaced(dynamic_cast<mitk::PlaneGeometry*>(planeGeometry.GetPointer()), 20);
   mitk::BaseGeometry::Pointer geometry3D = dynamic_cast< mitk::BaseGeometry* > ( slicedGeometry3D.GetPointer() );
-  geometry3D->SetImageGeometry( true );
 
   //Define origin for second Geometry3D;
   mitk::Point3D origin2;
@@ -799,12 +800,12 @@ int mitkClippedSurfaceBoundsCalculatorTest(int, char* [])
   //Initialize PlaneGeometry:
   mitk::PlaneGeometry::Pointer planeGeometry2 = mitk::PlaneGeometry::New();
   planeGeometry2->InitializePlane(origin2, normal2);
+  planeGeometry2->ImageGeometryOn();
 
   //Initialize SlicedGeometry3D:
   mitk::SlicedGeometry3D::Pointer secondSlicedGeometry3D = mitk::SlicedGeometry3D::New();
   secondSlicedGeometry3D->InitializeEvenlySpaced(dynamic_cast<mitk::PlaneGeometry*>(planeGeometry2.GetPointer()), 20);
   mitk::BaseGeometry::Pointer secondGeometry3D = dynamic_cast< mitk::BaseGeometry* > ( secondSlicedGeometry3D.GetPointer() );
-  secondGeometry3D->SetImageGeometry( true );
 
 
 

--- a/Modules/Core/test/mitkImageTest.cpp
+++ b/Modules/Core/test/mitkImageTest.cpp
@@ -279,13 +279,14 @@ int mitkImageTest(int argc, char* argv[])
   mitk::FillVector3D(spacing, 0.78, 0.91, 2.23);
 
   //InitializeStandardPlane(rightVector, downVector, spacing)
-  mitk::PlaneGeometry::Pointer planegeometry = mitk::PlaneGeometry::New();
-  planegeometry->InitializeStandardPlane(100, 100, right, bottom, &spacing);
-  planegeometry->SetOrigin(origin);
+  mitk::PlaneGeometry::Pointer planeGeometry = mitk::PlaneGeometry::New();
+  planeGeometry->SetImageGeometry(true);
+  planeGeometry->InitializeStandardPlane(100, 100, right, bottom, &spacing);
+  planeGeometry->SetOrigin(origin);
 
   // Testing Initialize(const mitk::PixelType& type, const mitk::Geometry3D& geometry, unsigned int slices) with PlaneGeometry and GetData(): ";
-  imgMem->Initialize( mitk::MakePixelType<int, int, 1>(), *planegeometry);
-  MITK_TEST_CONDITION_REQUIRED( imgMem->GetGeometry()->GetOrigin() == static_cast<mitk::BaseGeometry*>(planegeometry)->GetOrigin(), "Testing correct setting of geometry via initialize!");
+  imgMem->Initialize( mitk::MakePixelType<int, int, 1>(), *planeGeometry);
+  MITK_TEST_CONDITION_REQUIRED( imgMem->GetGeometry()->GetOrigin() == static_cast<mitk::BaseGeometry*>(planeGeometry)->GetOrigin(), "Testing correct setting of geometry via initialize!");
 
   try
   {
@@ -299,7 +300,7 @@ int mitkImageTest(int argc, char* argv[])
   MITK_TEST_CONDITION_REQUIRED( p!=NULL, "GetData() returned valid pointer.");
 
   // Testing Initialize(const mitk::PixelType& type, int sDim, const mitk::PlaneGeometry& geometry) and GetData(): ";
-  imgMem->Initialize( mitk::MakePixelType<int, int, 1>() , 40, *planegeometry);
+  imgMem->Initialize( mitk::MakePixelType<int, int, 1>() , 40, *planeGeometry);
 
   try
   {

--- a/Modules/Core/test/mitkSliceNavigationControllerTest.cpp
+++ b/Modules/Core/test/mitkSliceNavigationControllerTest.cpp
@@ -158,7 +158,7 @@ int testGeometry(const mitk::Geometry3D * geometry,
 
    std::cout << "Testing result of CreatedWorldGeometry(): ";
    mitk::Point3D axialcornerpoint0;
-   axialcornerpoint0 = cornerpoint0+bottom+normal*(numSlices-1+0.5); //really -1?
+   axialcornerpoint0 = cornerpoint0+bottom+normal*numSlices;
    result = compareGeometry(*sliceCtrl->GetCreatedWorldGeometry(), width, height, numSlices, widthInMM, heightInMM, thicknessInMM*numSlices, axialcornerpoint0, right, bottom*(-1.0), normal*(-1.0));
    if(result!=EXIT_SUCCESS)
    {
@@ -177,7 +177,7 @@ int testGeometry(const mitk::Geometry3D * geometry,
 
    std::cout << "Testing result of CreatedWorldGeometry(): ";
    mitk::Point3D frontalcornerpoint0;
-   frontalcornerpoint0 = cornerpoint0+geometry->GetAxisVector(1)*(+0.5/geometry->GetExtent(1));
+   frontalcornerpoint0 = cornerpoint0;
    result = compareGeometry(*sliceCtrl->GetCreatedWorldGeometry(), width, numSlices, height, widthInMM, thicknessInMM*numSlices, heightInMM, frontalcornerpoint0, right, normal, bottom);
    if(result!=EXIT_SUCCESS)
    {
@@ -196,7 +196,7 @@ int testGeometry(const mitk::Geometry3D * geometry,
 
    std::cout << "Testing result of CreatedWorldGeometry(): ";
    mitk::Point3D sagittalcornerpoint0;
-   sagittalcornerpoint0 = cornerpoint0+geometry->GetAxisVector(0)*(+0.5/geometry->GetExtent(0));
+   sagittalcornerpoint0 = cornerpoint0;
    result = compareGeometry(*sliceCtrl->GetCreatedWorldGeometry(), height, numSlices, width, heightInMM, thicknessInMM*numSlices, widthInMM, sagittalcornerpoint0, bottom, normal, right);
    if(result!=EXIT_SUCCESS)
    {

--- a/Modules/DataTypesExt/include/mitkAffineBaseDataInteractor3D.h
+++ b/Modules/DataTypesExt/include/mitkAffineBaseDataInteractor3D.h
@@ -46,7 +46,7 @@ public:
   itkFactorylessNewMacro(Self)
   itkCloneMacro(Self)
 
-  virtual void SetDataNode(DataNode* node);
+  virtual void SetDataNode(DataNode* node) override;
   void TranslateGeometry(mitk::Vector3D translate, mitk::BaseGeometry* geometry);
   void RotateGeometry(mitk::ScalarType angle, int rotationaxis, mitk::BaseGeometry* geometry);
   void ScaleGeometry(mitk::Point3D newScale, mitk::BaseGeometry* geometry);

--- a/Modules/QtWidgets/include/QmitkStdMultiWidget.h
+++ b/Modules/QtWidgets/include/QmitkStdMultiWidget.h
@@ -117,7 +117,7 @@ public:
 
   void AddPlanesToDataStorage();
 
-  void SetDataStorage( mitk::DataStorage* ds );
+  void SetDataStorage( mitk::DataStorage* dataStorage );
 
   /** \brief Listener to the CrosshairPositionEvent
 

--- a/Modules/QtWidgets/src/QmitkStdMultiWidget.cpp
+++ b/Modules/QtWidgets/src/QmitkStdMultiWidget.cpp
@@ -1255,13 +1255,16 @@ void QmitkStdMultiWidget::changeLayoutTo2DUpAnd3DDown()
   this->UpdateAllWidgets();
 }
 
-void QmitkStdMultiWidget::SetDataStorage( mitk::DataStorage* ds )
+void QmitkStdMultiWidget::SetDataStorage( mitk::DataStorage* dataStorage )
 {
-  mitk::BaseRenderer::GetInstance(mitkWidget1->GetRenderWindow())->SetDataStorage(ds);
-  mitk::BaseRenderer::GetInstance(mitkWidget2->GetRenderWindow())->SetDataStorage(ds);
-  mitk::BaseRenderer::GetInstance(mitkWidget3->GetRenderWindow())->SetDataStorage(ds);
-  mitk::BaseRenderer::GetInstance(mitkWidget4->GetRenderWindow())->SetDataStorage(ds);
-  m_DataStorage = ds;
+  if (m_DataStorage != dataStorage)
+  {
+    mitk::BaseRenderer::GetInstance(mitkWidget1->GetRenderWindow())->SetDataStorage(dataStorage);
+    mitk::BaseRenderer::GetInstance(mitkWidget2->GetRenderWindow())->SetDataStorage(dataStorage);
+    mitk::BaseRenderer::GetInstance(mitkWidget3->GetRenderWindow())->SetDataStorage(dataStorage);
+    mitk::BaseRenderer::GetInstance(mitkWidget4->GetRenderWindow())->SetDataStorage(dataStorage);
+    m_DataStorage = dataStorage;
+  }
 }
 
 void QmitkStdMultiWidget::Fit()


### PR DESCRIPTION
These changes put the origin of a 'non-image' sliced geometry to the bottom-left-back corner of the 3D volume, as described in the documentation, and as opposed to the bottom-left corner of the back slice, which is half a voxel ahead of the back plane of the volume. (It crosscuts the back slice in the middle.)

This branch is *not* ready to be merged yet. A few unit tests are fixed, but a few others are still broken:

	- mitkPointSetDataInteractorTest
	- mitkSurfaceVtkMapper2D3DTest
	- mitkTextOverlay3DRendering3DTest_ball
	- mitkTextOverlay3DColorRenderingTest_ball

First of all, it has to be decided if the issue is valid or not. If not, the documentation has to be corrected, otherwise the remaining unit tests need to be fixed.

Signed-off-by: Miklos Espak <m.espak@ucl.ac.uk>