### PR TITLE
Fixed drag-and-drop crash in data manager

### DIFF
--- a/Modules/QtWidgets/src/QmitkDataStorageTreeModel.cpp
+++ b/Modules/QtWidgets/src/QmitkDataStorageTreeModel.cpp
@@ -167,6 +167,10 @@ bool QmitkDataStorageTreeModel::dropMimeData(
 
     // First we extract a Qlist of TreeItem* pointers.
     QList<TreeItem *> listOfItemsToDrop = ToTreeItemPtrList(data);
+    if (listOfItemsToDrop.size() == 0)
+    {
+      return false;
+    }
 
     // Retrieve the TreeItem* where we are dropping stuff, and its parent.
     TreeItem *dropItem = this->TreeItemFromIndex(parent);


### PR DESCRIPTION
QmitkDataStorageTreeModel accepts "application/x-qabstractitemmodeldatalist" format.
It's general tree data item format that means that QmitkDataStorageTreeModel accepts almost any item from any QTreeWidget.
But later QmitkDataStorageTreeModel casts data items to "application/x-qmitk-datastorage-treeitem-ptrs" and if cast fails, ToTreeItemPtrList() returns empty list. When accessing the first element of this empty list, crash occurs.

I can't reproduce this crash in MITK because I didn't find the second tree widget but I encountered this in our MITK fork.

Now there is a check on list's size before using it.

Signed-off-by: KuznetsovAlexander <KuznetsovAlexander@rambler.ru>