### PR TITLE
Bug 20180 axial renderer bottom origin

### DIFF
--- a/Modules/Core/src/Controllers/mitkSliceNavigationController.cpp
+++ b/Modules/Core/src/Controllers/mitkSliceNavigationController.cpp
@@ -174,7 +174,7 @@ namespace mitk
     {
       if (m_ViewDirection == Axial)
       {
-        this->Update(Axial, false, false, true);
+        this->Update(Axial, true, false, true);
       }
       else
       {

--- a/Modules/Core/test/mitkSliceNavigationControllerTest.cpp
+++ b/Modules/Core/test/mitkSliceNavigationControllerTest.cpp
@@ -178,7 +178,7 @@ int testGeometry(const mitk::Geometry3D *geometry,
 
   std::cout << "Testing result of CreatedWorldGeometry(): ";
   mitk::Point3D axialcornerpoint0;
-  axialcornerpoint0 = cornerpoint0 + bottom + normal * (numSlices - 1 + 0.5); // really -1?
+  axialcornerpoint0 = cornerpoint0 + bottom;
   result = compareGeometry(*sliceCtrl->GetCreatedWorldGeometry(),
                            width,
                            height,
@@ -189,7 +189,7 @@ int testGeometry(const mitk::Geometry3D *geometry,
                            axialcornerpoint0,
                            right,
                            bottom * (-1.0),
-                           normal * (-1.0));
+                           normal);
   if (result != EXIT_SUCCESS)
   {
     std::cout << "[FAILED]" << std::endl;

--- a/Plugins/org.mitk.gui.qt.imagenavigator/src/internal/QmitkImageNavigatorView.cpp
+++ b/Plugins/org.mitk.gui.qt.imagenavigator/src/internal/QmitkImageNavigatorView.cpp
@@ -81,7 +81,6 @@ void QmitkImageNavigatorView::CreateQtPartControl(QWidget *parent)
   // create GUI widgets
   m_Parent = parent;
   m_Controls.setupUi(parent);
-  m_Controls.m_SliceNavigatorAxial->SetInverseDirection(true);
 
   connect(m_Controls.m_XWorldCoordinateSpinBox, SIGNAL(valueChanged(double)), this, SLOT(OnMillimetreCoordinateValueChanged()));
   connect(m_Controls.m_YWorldCoordinateSpinBox, SIGNAL(valueChanged(double)), this, SLOT(OnMillimetreCoordinateValueChanged()));


### PR DESCRIPTION
This puts the origin in the axial renderer in the bottom rather than the top.

Signed-off-by: Miklos Espak m.espak@ucl.ac.uk
