### PR TITLE
SlicedGeometry3D::GetReferenceGeometry() function for API consistency

### DIFF
--- a/Modules/Core/include/mitkPlaneGeometry.h
+++ b/Modules/Core/include/mitkPlaneGeometry.h
@@ -544,12 +544,12 @@ namespace mitk
     * This would usually be the BaseGeometry of the underlying dataset, but
     * setting it is optional.
     */
-    void SetReferenceGeometry(mitk::BaseGeometry *geometry);
+    void SetReferenceGeometry(const mitk::BaseGeometry *geometry);
 
     /**
     * \brief Get the geometrical frame of reference for this PlaneGeometry.
     */
-    BaseGeometry *GetReferenceGeometry() const;
+    const BaseGeometry *GetReferenceGeometry() const;
     bool HasReferenceGeometry() const;
 
   protected:
@@ -561,7 +561,7 @@ namespace mitk
 
     virtual void PrintSelf(std::ostream &os, itk::Indent indent) const override;
 
-    mitk::BaseGeometry *m_ReferenceGeometry;
+    const mitk::BaseGeometry *m_ReferenceGeometry;
 
     //##Documentation
     //## @brief PreSetSpacing

--- a/Modules/Core/include/mitkSlicedGeometry3D.h
+++ b/Modules/Core/include/mitkSlicedGeometry3D.h
@@ -126,7 +126,11 @@ namespace mitk
     */
     virtual bool IsValidSlice(int s = 0) const;
 
-    virtual void SetReferenceGeometry(BaseGeometry *referenceGeometry);
+    virtual const BaseGeometry* GetReferenceGeometry() const;
+
+    virtual void SetReferenceGeometry(const BaseGeometry *referenceGeometry);
+
+    bool HasReferenceGeometry() const;
 
     /**
     * \brief Set the SliceNavigationController corresponding to this sliced
@@ -303,7 +307,7 @@ namespace mitk
     unsigned int m_Slices;
 
     /** Underlying BaseGeometry for this SlicedGeometry */
-    mitk::BaseGeometry *m_ReferenceGeometry;
+    const mitk::BaseGeometry *m_ReferenceGeometry;
 
     /** SNC correcsponding to this geometry; used to reflect changes in the
     * number of slices due to rotation. */

--- a/Modules/Core/src/Algorithms/mitkPlaneGeometryDataToSurfaceFilter.cpp
+++ b/Modules/Core/src/Algorithms/mitkPlaneGeometryDataToSurfaceFilter.cpp
@@ -263,7 +263,7 @@ void mitk::PlaneGeometryDataToSurfaceFilter::GenerateOutputInformation()
       m_Transform->Identity();
       m_Transform->Concatenate(planeGeometry->GetVtkTransform()->GetLinearInverse());
 
-      BaseGeometry *referenceGeometry = planeGeometry->GetReferenceGeometry();
+      const BaseGeometry *referenceGeometry = planeGeometry->GetReferenceGeometry();
       if (referenceGeometry)
       {
         m_Transform->Concatenate(referenceGeometry->GetVtkTransform());

--- a/Modules/Core/src/DataManagement/mitkPlaneGeometry.cpp
+++ b/Modules/Core/src/DataManagement/mitkPlaneGeometry.cpp
@@ -385,7 +385,7 @@ namespace mitk
                                               bool frontside,
                                               bool rotated)
   {
-    this->SetReferenceGeometry(const_cast<BaseGeometry *>(geometry3D));
+    this->SetReferenceGeometry(geometry3D);
 
     ScalarType width, height;
 
@@ -910,7 +910,7 @@ namespace mitk
     assert(false);
   }
 
-  void PlaneGeometry::SetReferenceGeometry(mitk::BaseGeometry *geometry) { m_ReferenceGeometry = geometry; }
-  mitk::BaseGeometry *PlaneGeometry::GetReferenceGeometry() const { return m_ReferenceGeometry; }
+  void PlaneGeometry::SetReferenceGeometry(const mitk::BaseGeometry *geometry) { m_ReferenceGeometry = geometry; }
+  const mitk::BaseGeometry *PlaneGeometry::GetReferenceGeometry() const { return m_ReferenceGeometry; }
   bool PlaneGeometry::HasReferenceGeometry() const { return (m_ReferenceGeometry != nullptr); }
 } // namespace

--- a/Modules/Core/src/DataManagement/mitkSlicedGeometry3D.cpp
+++ b/Modules/Core/src/DataManagement/mitkSlicedGeometry3D.cpp
@@ -236,7 +236,7 @@ void mitk::SlicedGeometry3D::InitializePlanes(const mitk::BaseGeometry *geometry
                                               bool frontside,
                                               bool rotated)
 {
-  m_ReferenceGeometry = const_cast<BaseGeometry *>(geometry3D);
+  m_ReferenceGeometry = geometry3D;
 
   PlaneGeometry::Pointer planeGeometry = mitk::PlaneGeometry::New();
   planeGeometry->InitializeStandardPlane(geometry3D, top, planeorientation, frontside, rotated);
@@ -468,7 +468,12 @@ bool mitk::SlicedGeometry3D::IsValidSlice(int s) const
   return ((s >= 0) && (s < (int)m_Slices));
 }
 
-void mitk::SlicedGeometry3D::SetReferenceGeometry(BaseGeometry *referenceGeometry)
+const mitk::BaseGeometry *mitk::SlicedGeometry3D::GetReferenceGeometry() const
+{
+  return m_ReferenceGeometry;
+}
+
+void mitk::SlicedGeometry3D::SetReferenceGeometry(const BaseGeometry *referenceGeometry)
 {
   m_ReferenceGeometry = referenceGeometry;
 
@@ -478,6 +483,11 @@ void mitk::SlicedGeometry3D::SetReferenceGeometry(BaseGeometry *referenceGeometr
   {
     (*it)->SetReferenceGeometry(referenceGeometry);
   }
+}
+
+bool mitk::SlicedGeometry3D::HasReferenceGeometry() const
+{
+  return ( m_ReferenceGeometry != nullptr );
 }
 
 void mitk::SlicedGeometry3D::PreSetSpacing(const mitk::Vector3D &aSpacing)

--- a/Modules/Core/src/Rendering/mitkPlaneGeometryDataVtkMapper3D.cpp
+++ b/Modules/Core/src/Rendering/mitkPlaneGeometryDataVtkMapper3D.cpp
@@ -269,7 +269,7 @@ namespace mitk
       // Clip the PlaneGeometry with the reference geometry bounds (if available)
       if (input->GetPlaneGeometry()->HasReferenceGeometry())
       {
-        BaseGeometry *referenceGeometry = input->GetPlaneGeometry()->GetReferenceGeometry();
+        const BaseGeometry *referenceGeometry = input->GetPlaneGeometry()->GetReferenceGeometry();
 
         BoundingBox::PointType boundingBoxMin, boundingBoxMax;
         boundingBoxMin = referenceGeometry->GetBoundingBox()->GetMinimum();

--- a/Modules/Segmentation/Algorithms/mitkDiffSliceOperation.h
+++ b/Modules/Segmentation/Algorithms/mitkDiffSliceOperation.h
@@ -107,7 +107,7 @@ namespace mitk
 
     unsigned long m_DeleteObserverTag;
 
-    mitk::BaseGeometry::Pointer m_GuardReferenceGeometry;
+    mitk::BaseGeometry::ConstPointer m_GuardReferenceGeometry;
   };
 }
 #endif


### PR DESCRIPTION
Signed-off-by: Miklos Espak m.espak@ucl.ac.uk
