### PR TITLE
Equality checks when setting data storage for renderers

### DIFF
--- a/Modules/Core/src/Rendering/mitkVtkPropRenderer.cpp
+++ b/Modules/Core/src/Rendering/mitkVtkPropRenderer.cpp
@@ -123,7 +123,7 @@ mitk::VtkPropRenderer::~VtkPropRenderer()
 
 void mitk::VtkPropRenderer::SetDataStorage(mitk::DataStorage *storage)
 {
-  if (storage == NULL)
+  if (storage == NULL || storage == m_DataStorage)
     return;
 
   BaseRenderer::SetDataStorage(storage);

--- a/Modules/QtWidgets/src/QmitkStdMultiWidget.cpp
+++ b/Modules/QtWidgets/src/QmitkStdMultiWidget.cpp
@@ -1282,6 +1282,11 @@ void QmitkStdMultiWidget::changeLayoutTo2DUpAnd3DDown()
 
 void QmitkStdMultiWidget::SetDataStorage(mitk::DataStorage *ds)
 {
+  if (ds == m_DataStorage)
+  {
+    return;
+  }
+
   mitk::BaseRenderer::GetInstance(mitkWidget1->GetRenderWindow())->SetDataStorage(ds);
   mitk::BaseRenderer::GetInstance(mitkWidget2->GetRenderWindow())->SetDataStorage(ds);
   mitk::BaseRenderer::GetInstance(mitkWidget3->GetRenderWindow())->SetDataStorage(ds);


### PR DESCRIPTION
Then the data storage of a renderer is set, a bounding box is calculated
from the currently visible data nodes in the data storage, and the renderer
is updated. The setters do not check if the 'new' data storage is the same
as the current one, which results that the bounding box is recalculated
and the renderer is updated again, unnecessarily.

This changes adds a check to the setters to skip the update if the data
storage is the same.

The data storage is set from the constructor of the renderer (to the data
storage of the rendering manager), and it is also set by explicit
SetDataStorage calls after the renderers have been constructed. Ideally,
the repeated calls to the setter should be eliminated, but with this
change the repeated calls will return immediately, at least.

Signed-off-by: Miklos Espak <m.espak@ucl.ac.uk>