### PR TITLE
Render meta information inside StdMultiwidget on crosshair position change

### DIFF
--- a/Modules/QtWidgets/include/QmitkStdMultiWidget.h
+++ b/Modules/QtWidgets/include/QmitkStdMultiWidget.h
@@ -137,10 +137,23 @@ public:
 
   bool IsCornerAnnotationVisible(void) const;
 
+  void setDisplayMetaInfo(bool metainfo);
+
 protected:
   void UpdateAllWidgets();
 
   void HideAllWidgetToolbars();
+
+  bool m_displayMetaInfo;
+
+  mitk::PropertyList::Pointer imageProperties;
+  unsigned long imageMTime;
+
+  vtkCornerAnnotation* cornerText[4];
+  vtkTextProperty* textProp[4];
+  vtkRenderer* ren[4];
+
+  void setCornerAnnotation(int corner, int i, const char* text);
 
   mitk::DataNode::Pointer GetTopLayerNode(mitk::DataStorage::SetOfObjects::ConstPointer nodes);
 


### PR DESCRIPTION
QmitkStdMultiWidget::setDisplayMetaInfo is used to enable or disable meta information on 3D view (will be added to berry properties)
When meta information is enabled (by default) logo on 3D view is disabled