### PR TITLE
Fix for 3D-interpolation crash on closing plugin or deleting data

### DIFF
--- a/Modules/SegmentationUI/Qmitk/QmitkSlicesInterpolator.h
+++ b/Modules/SegmentationUI/Qmitk/QmitkSlicesInterpolator.h
@@ -242,6 +242,8 @@ private:
 
   mitk::SegmentationInterpolationController::Pointer m_Interpolator;
   mitk::SurfaceInterpolationController::Pointer m_SurfaceInterpolator;
+    void WaitForFutures();
+    void nodeRemoved(const mitk::DataNode* node);
 
   mitk::FeatureBasedEdgeDetectionFilter::Pointer m_EdgeDetector;
   mitk::PointCloudScoringFilter::Pointer m_PointScorer;


### PR DESCRIPTION
If you close working data or segmentation plugin when 3d-interpolation is in progress, this will lead to crash. This happens because QFuture will still be running but there will be no data for it.

This PR adds waiting for future's complete before deleting node or closing plugin.

Signed-off-by: KuznetsovAlexander <KuznetsovAlexander@rambler.ru>