### PR TITLE
T22136, T22159: Fix for 3D-interpolation crash on closing plugin or deleting data

### DIFF
--- a/Modules/SegmentationUI/Qmitk/QmitkSlicesInterpolator.cpp
+++ b/Modules/SegmentationUI/Qmitk/QmitkSlicesInterpolator.cpp
@@ -885,7 +885,7 @@ void ::QmitkSlicesInterpolator::OnSuggestPlaneClicked()
 void ::QmitkSlicesInterpolator::RunPlaneSuggestion()
 {
   if (m_FirstRun)
-    mitk::ProgressBar::GetInstance()->AddStepsToDo(8);
+    mitk::ProgressBar::GetInstance()->AddStepsToDo(7);
   else
     mitk::ProgressBar::GetInstance()->AddStepsToDo(3);
 

--- a/Modules/SegmentationUI/Qmitk/QmitkSlicesInterpolator.cpp
+++ b/Modules/SegmentationUI/Qmitk/QmitkSlicesInterpolator.cpp
@@ -199,19 +199,27 @@ QmitkSlicesInterpolator::QmitkSlicesInterpolator(QWidget *parent, const char * /
 
 void QmitkSlicesInterpolator::SetDataStorage(mitk::DataStorage::Pointer storage)
 {
-  if (m_DataStorage)
+  if (m_DataStorage == storage)
+  {
+    return;
+  }
+
+  if (m_DataStorage.IsNotNull())
   {
     m_DataStorage->RemoveNodeEvent.RemoveListener(
-      mitk::MessageDelegate1<QmitkSlicesInterpolator, const mitk::DataNode*>(this, &QmitkSlicesInterpolator::nodeRemoved)
+      mitk::MessageDelegate1<QmitkSlicesInterpolator, const mitk::DataNode*>(this, &QmitkSlicesInterpolator::NodeRemoved)
     );
   }
    
   m_DataStorage = storage;
   m_SurfaceInterpolator->SetDataStorage(storage);
 
-  m_DataStorage->RemoveNodeEvent.AddListener(
-    mitk::MessageDelegate1<QmitkSlicesInterpolator, const mitk::DataNode*>(this, &QmitkSlicesInterpolator::nodeRemoved)
-  );
+  if (m_DataStorage.IsNotNull())
+  {
+    m_DataStorage->RemoveNodeEvent.AddListener(
+      mitk::MessageDelegate1<QmitkSlicesInterpolator, const mitk::DataNode*>(this, &QmitkSlicesInterpolator::NodeRemoved)
+    );
+  }
 }
 
 mitk::DataStorage *QmitkSlicesInterpolator::GetDataStorage()
@@ -315,12 +323,11 @@ QmitkSlicesInterpolator::~QmitkSlicesInterpolator()
 
   WaitForFutures();
 
-  m_DataStorage->RemoveNodeEvent.RemoveListener(
-    mitk::MessageDelegate1<QmitkSlicesInterpolator, const mitk::DataNode*>(this, &QmitkSlicesInterpolator::nodeRemoved)
-  );
-
   if (m_DataStorage.IsNotNull()) 
   {
+    m_DataStorage->RemoveNodeEvent.RemoveListener(
+      mitk::MessageDelegate1<QmitkSlicesInterpolator, const mitk::DataNode*>(this, &QmitkSlicesInterpolator::NodeRemoved)
+    );
     if (m_DataStorage->Exists(m_3DContourNode))
       m_DataStorage->Remove(m_3DContourNode);
     if (m_DataStorage->Exists(m_InterpolatedSurfaceNode))
@@ -1334,7 +1341,7 @@ void QmitkSlicesInterpolator::WaitForFutures()
   }
 }
 
-void QmitkSlicesInterpolator::nodeRemoved(const mitk::DataNode* node)
+void QmitkSlicesInterpolator::NodeRemoved(const mitk::DataNode* node)
 {
   if ((m_ToolManager && m_ToolManager->GetWorkingData(0) == node) ||
       node == m_3DContourNode ||

--- a/Modules/SegmentationUI/Qmitk/QmitkSlicesInterpolator.h
+++ b/Modules/SegmentationUI/Qmitk/QmitkSlicesInterpolator.h
@@ -239,11 +239,11 @@ private:
   void Show2DInterpolationControls(bool show);
   void Show3DInterpolationControls(bool show);
   void CheckSupportedImageDimension();
+  void WaitForFutures();
+  void NodeRemoved(const mitk::DataNode* node);
 
   mitk::SegmentationInterpolationController::Pointer m_Interpolator;
   mitk::SurfaceInterpolationController::Pointer m_SurfaceInterpolator;
-    void WaitForFutures();
-    void nodeRemoved(const mitk::DataNode* node);
 
   mitk::FeatureBasedEdgeDetectionFilter::Pointer m_EdgeDetector;
   mitk::PointCloudScoringFilter::Pointer m_PointScorer;

--- a/Modules/SegmentationUI/Qmitk/QmitkSlicesInterpolator.h
+++ b/Modules/SegmentationUI/Qmitk/QmitkSlicesInterpolator.h
@@ -242,6 +242,8 @@ private:
 
   mitk::SegmentationInterpolationController::Pointer m_Interpolator;
   mitk::SurfaceInterpolationController::Pointer m_SurfaceInterpolator;
+    void WaitForFutures();
+    void nodeRemoved(const mitk::DataNode* node);
 
   mitk::FeatureBasedEdgeDetectionFilter::Pointer m_EdgeDetector;
   mitk::PointCloudScoringFilter::Pointer m_PointScorer;


### PR DESCRIPTION
If you close working data or segmentation plugin when 3d-interpolation is in progress, this will lead to crash. This happens because QFuture will still be running but there will be no data for it.

This PR adds waiting for future's complete before deleting node or closing plugin.

Signed-off-by: KuznetsovAlexander KuznetsovAlexander@rambler.ru