### PR TITLE
Fix the render window menus on OS X

### DIFF
--- a/Modules/QtWidgets/include/QmitkRenderWindow.h
+++ b/Modules/QtWidgets/include/QmitkRenderWindow.h
@@ -67,6 +67,13 @@ public:
    */
   virtual void SetResendQtEvents(bool resend);
 
+  void ShowMenu() { m_MenuWidget->ShowMenu(); }
+  void HideMenu() { m_MenuWidget->HideMenu(); }
+  void ChangeFullScreenIcon(const bool fullscreen)
+  {
+    m_MenuWidget->ChangeFullScreenIcon(fullscreen);
+  }
+
   // Set Layout Index to define the Layout Type
   void SetLayoutIndex(unsigned int layoutIndex);
 
@@ -76,8 +83,6 @@ public:
   // MenuWidget need to update the Layout Design List when Layout had changed
   void LayoutDesignListChanged(int layoutDesignIndex);
 
-  void HideRenderWindowMenu();
-
   // Activate or Deactivate MenuWidget.
   void ActivateMenuWidget(bool state, QmitkStdMultiWidget *stdMultiWidget = 0);
 
@@ -85,7 +90,6 @@ public:
   // Get it from the QVTKWidget parent
   virtual vtkRenderWindow *GetVtkRenderWindow() override { return GetRenderWindow(); }
   virtual vtkRenderWindowInteractor *GetVtkRenderWindowInteractor() override { return NULL; }
-  void FullScreenMode(bool state);
 
 protected:
   // overloaded move handler
@@ -121,8 +125,6 @@ protected:
   virtual void wheelEvent(QWheelEvent *) override;
 #endif
 
-  void AdjustRenderWindowMenuVisibility(const QPoint &pos);
-
 signals:
 
   void ResetView();
@@ -141,8 +143,6 @@ protected slots:
   void OnChangeLayoutDesign(int layoutDesignIndex);
 
   void OnWidgetPlaneModeChanged(int);
-
-  void DeferredHideMenu();
 
 private:
   // Helper Functions to Convert Qt-Events to Mitk-Events

--- a/Modules/QtWidgets/include/QmitkRenderWindowMenu.h
+++ b/Modules/QtWidgets/include/QmitkRenderWindowMenu.h
@@ -83,15 +83,12 @@ public:
   to disable and all other to enable. */
   void UpdateLayoutDesignList(int layoutDesignIndex);
 
-/*! Move menu widget to correct position (right upper corner). E.g. it is necessary when the full-screen mode
-is activated.*/
-#ifdef QMITK_USE_EXTERNAL_RENDERWINDOW_MENU
-  void MoveWidgetToCorrectPos(float opacity);
-#else
-  void MoveWidgetToCorrectPos(float /*opacity*/);
-#endif
+  /*! Change Icon of full-screen button depending on full-screen mode. */
+  void ChangeFullScreenIcon(const bool);
 
-  void ChangeFullScreenMode(bool state);
+  /*! Move menu widget to correct position (right upper corner). E.g. it is necessary when the full-screen mode
+  is activated.*/
+  void MoveWidgetToCorrectPos();
 
   void NotifyNewWidgetPlanesMode(int mode);
 
@@ -112,9 +109,6 @@ protected:
   this is not supported yet. */
   void UpdateLayoutList();
 
-  /*! Change Icon of full-screen button depending on full-screen mode. */
-  void ChangeFullScreenIcon();
-
   int currentCrosshairRotationMode;
 
 public slots:
@@ -131,12 +125,6 @@ signals:
   /*! emit signal, when layout design changed by the setting menu.*/
   void SignalChangeLayoutDesign(int layoutDesign);
 
-public slots:
-
-  void DeferredHideMenu();
-  void DeferredShowMenu();
-  void smoothHide();
-
 protected slots:
 
   ///
@@ -150,7 +138,6 @@ protected slots:
   ///
   void OnAutoRotationActionTriggered();
 
-  void enterEvent(QEvent * /*e*/) override;
   void leaveEvent(QEvent * /*e*/) override;
   void OnTSNumChanged(int);
 
@@ -317,11 +304,6 @@ protected:
    * layout design will restore.*/
   unsigned int m_OldLayoutDesign;
 
-  /*! Flag if full-screen mode is activated or deactivated. */
-  bool m_FullScreenMode;
-
-  bool m_Entered;
-
 private:
   mitk::BaseRenderer::Pointer m_Renderer;
 
@@ -331,7 +313,8 @@ private:
   /// a timer for the auto rotate action
   ///
   QTimer m_AutoRotationTimer;
-  QTimer m_HideTimer;
+
+  bool m_MenuIsShown;
 
   QWidget *m_Parent;
 };

--- a/Modules/QtWidgets/include/QmitkStdMultiWidget.h
+++ b/Modules/QtWidgets/include/QmitkStdMultiWidget.h
@@ -140,8 +140,6 @@ public:
 protected:
   void UpdateAllWidgets();
 
-  void HideAllWidgetToolbars();
-
   mitk::DataNode::Pointer GetTopLayerNode(mitk::DataStorage::SetOfObjects::ConstPointer nodes);
 
 public slots:
@@ -419,6 +417,11 @@ protected:
    * @return the complete CornerAnnotation.
    */
   vtkSmartPointer<vtkCornerAnnotation> CreateCornerAnnotation(std::string text, mitk::Color color);
+
+  /**
+   * @brief Clear splitters and widgets each time a new layout is picked.
+   */
+  void ClearWidgetsForNewLayout();
 
   /**
    * @brief FillGradientBackgroundWithBlack Internal helper method to initialize the

--- a/Modules/QtWidgets/src/QmitkStdMultiWidget.cpp
+++ b/Modules/QtWidgets/src/QmitkStdMultiWidget.cpp
@@ -90,30 +90,11 @@ QmitkStdMultiWidget::QmitkStdMultiWidget(QWidget *parent,
   // Create Widget manually
   /*******************************/
 
-  // create Layouts
-  QmitkStdMultiWidgetLayout = new QHBoxLayout(this);
-  QmitkStdMultiWidgetLayout->setContentsMargins(0, 0, 0, 0);
-
-  // Set Layout to widget
-  this->setLayout(QmitkStdMultiWidgetLayout);
-
-  // create main splitter
-  m_MainSplit = new QSplitter(this);
-  QmitkStdMultiWidgetLayout->addWidget(m_MainSplit);
-
-  // create m_LayoutSplit  and add to the mainSplit
-  m_LayoutSplit = new QSplitter(Qt::Vertical, m_MainSplit);
-  m_MainSplit->addWidget(m_LayoutSplit);
-
-  // create m_SubSplit1 and m_SubSplit2
-  m_SubSplit1 = new QSplitter(m_LayoutSplit);
-  m_SubSplit2 = new QSplitter(m_LayoutSplit);
-
-  // creae Widget Container
-  mitkWidget1Container = new QWidget(m_SubSplit1);
-  mitkWidget2Container = new QWidget(m_SubSplit1);
-  mitkWidget3Container = new QWidget(m_SubSplit2);
-  mitkWidget4Container = new QWidget(m_SubSplit2);
+  // Creae Widget Container
+  mitkWidget1Container = new QWidget;
+  mitkWidget2Container = new QWidget;
+  mitkWidget3Container = new QWidget;
+  mitkWidget4Container = new QWidget;
 
   mitkWidget1Container->setContentsMargins(0, 0, 0, 0);
   mitkWidget2Container->setContentsMargins(0, 0, 0, 0);
@@ -152,13 +133,6 @@ QmitkStdMultiWidget::QmitkStdMultiWidget(QWidget *parent,
   mitkWidget2Container->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
   mitkWidget3Container->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
   mitkWidget4Container->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
-
-  // insert Widget Container into the splitters
-  m_SubSplit1->addWidget(mitkWidget1Container);
-  m_SubSplit1->addWidget(mitkWidget2Container);
-
-  m_SubSplit2->addWidget(mitkWidget3Container);
-  m_SubSplit2->addWidget(mitkWidget4Container);
 
   // Create RenderWindows 1
   mitkWidget1 = new QmitkRenderWindow(mitkWidget1Container, name + ".widget1", NULL, m_RenderingManager, renderingMode);
@@ -203,7 +177,7 @@ QmitkStdMultiWidget::QmitkStdMultiWidget(QWidget *parent,
   connect(this, SIGNAL(WidgetNotifyNewCrossHairMode(int)), mitkWidget4, SLOT(OnWidgetPlaneModeChanged(int)));
 
   // Create Level Window Widget
-  levelWindowWidget = new QmitkLevelWindowWidget(m_MainSplit); // this
+  levelWindowWidget = new QmitkLevelWindowWidget;
   levelWindowWidget->setObjectName(QString::fromUtf8("levelWindowWidget"));
   QSizePolicy sizePolicy(QSizePolicy::Preferred, QSizePolicy::Preferred);
   sizePolicy.setHorizontalStretch(0);
@@ -211,12 +185,6 @@ QmitkStdMultiWidget::QmitkStdMultiWidget(QWidget *parent,
   sizePolicy.setHeightForWidth(levelWindowWidget->sizePolicy().hasHeightForWidth());
   levelWindowWidget->setSizePolicy(sizePolicy);
   levelWindowWidget->setMaximumWidth(50);
-
-  // add LevelWindow Widget to mainSplitter
-  m_MainSplit->addWidget(levelWindowWidget);
-
-  // show mainSplitt and add to Layout
-  m_MainSplit->show();
 
   // resize Image.
   this->resize(QSize(364, 477).expandedTo(minimumSizeHint()));
@@ -226,6 +194,8 @@ QmitkStdMultiWidget::QmitkStdMultiWidget(QWidget *parent,
 
   // Activate Widget Menu
   this->ActivateMenuWidget(true);
+
+  this->OnLayoutDesignChanged(LAYOUT_DEFAULT);
 }
 
 void QmitkStdMultiWidget::InitializeWidget()
@@ -453,11 +423,6 @@ void QmitkStdMultiWidget::changeLayoutTo2DImagesUp()
 {
   SMW_INFO << "changing layout to 2D images up... " << std::endl;
 
-  // Hide all Menu Widgets
-  this->HideAllWidgetToolbars();
-
-  delete QmitkStdMultiWidgetLayout;
-
   // create Main Layout
   QmitkStdMultiWidgetLayout = new QHBoxLayout(this);
 
@@ -485,19 +450,14 @@ void QmitkStdMultiWidget::changeLayoutTo2DImagesUp()
   m_SubSplit1->addWidget(mitkWidget3Container);
 
   // set SplitterSize for splitter top
-  QList<int> splitterSize;
-  splitterSize.push_back(1000);
-  splitterSize.push_back(1000);
-  splitterSize.push_back(1000);
-  m_SubSplit1->setSizes(splitterSize);
+  const QList<int> oneThirdEach{ 1000, 1000, 1000 };
+  m_SubSplit1->setSizes(oneThirdEach);
 
   // insert Widget Container into splitter bottom
   m_SubSplit2->addWidget(mitkWidget4Container);
 
   // set SplitterSize for splitter m_LayoutSplit
-  splitterSize.clear();
-  splitterSize.push_back(400);
-  splitterSize.push_back(1000);
+  const QList<int> splitterSize{ 400, 1000 };
   m_LayoutSplit->setSizes(splitterSize);
 
   // show mainSplitt
@@ -512,28 +472,11 @@ void QmitkStdMultiWidget::changeLayoutTo2DImagesUp()
     mitkWidget3->show();
   if (mitkWidget4->isHidden())
     mitkWidget4->show();
-
-  // Change Layout Name
-  m_Layout = LAYOUT_2D_IMAGES_UP;
-
-  // update Layout Design List
-  mitkWidget1->LayoutDesignListChanged(LAYOUT_2D_IMAGES_UP);
-  mitkWidget2->LayoutDesignListChanged(LAYOUT_2D_IMAGES_UP);
-  mitkWidget3->LayoutDesignListChanged(LAYOUT_2D_IMAGES_UP);
-  mitkWidget4->LayoutDesignListChanged(LAYOUT_2D_IMAGES_UP);
-
-  // update Alle Widgets
-  this->UpdateAllWidgets();
 }
 
 void QmitkStdMultiWidget::changeLayoutTo2DImagesLeft()
 {
   SMW_INFO << "changing layout to 2D images left... " << std::endl;
-
-  // Hide all Menu Widgets
-  this->HideAllWidgetToolbars();
-
-  delete QmitkStdMultiWidgetLayout;
 
   // create Main Layout
   QmitkStdMultiWidgetLayout = new QHBoxLayout(this);
@@ -559,18 +502,13 @@ void QmitkStdMultiWidget::changeLayoutTo2DImagesLeft()
   m_SubSplit1->addWidget(mitkWidget3Container);
 
   // set splitterSize of SubSplit1
-  QList<int> splitterSize;
-  splitterSize.push_back(1000);
-  splitterSize.push_back(1000);
-  splitterSize.push_back(1000);
-  m_SubSplit1->setSizes(splitterSize);
+  const QList<int> oneThirdEach{ 1000, 1000, 1000 };
+  m_SubSplit1->setSizes(oneThirdEach);
 
   m_SubSplit2->addWidget(mitkWidget4Container);
 
   // set splitterSize of Layout Split
-  splitterSize.clear();
-  splitterSize.push_back(400);
-  splitterSize.push_back(1000);
+  const QList<int> splitterSize{ 400, 1000 };
   m_LayoutSplit->setSizes(splitterSize);
 
   // show mainSplitt and add to Layout
@@ -585,18 +523,6 @@ void QmitkStdMultiWidget::changeLayoutTo2DImagesLeft()
     mitkWidget3->show();
   if (mitkWidget4->isHidden())
     mitkWidget4->show();
-
-  // update Layout Name
-  m_Layout = LAYOUT_2D_IMAGES_LEFT;
-
-  // update Layout Design List
-  mitkWidget1->LayoutDesignListChanged(LAYOUT_2D_IMAGES_LEFT);
-  mitkWidget2->LayoutDesignListChanged(LAYOUT_2D_IMAGES_LEFT);
-  mitkWidget3->LayoutDesignListChanged(LAYOUT_2D_IMAGES_LEFT);
-  mitkWidget4->LayoutDesignListChanged(LAYOUT_2D_IMAGES_LEFT);
-
-  // update Alle Widgets
-  this->UpdateAllWidgets();
 }
 
 void QmitkStdMultiWidget::SetDecorationProperties(std::string text, mitk::Color color, int widgetNumber)
@@ -661,11 +587,6 @@ void QmitkStdMultiWidget::changeLayoutToDefault()
 {
   SMW_INFO << "changing layout to default... " << std::endl;
 
-  // Hide all Menu Widgets
-  this->HideAllWidgetToolbars();
-
-  delete QmitkStdMultiWidgetLayout;
-
   // create Main Layout
   QmitkStdMultiWidgetLayout = new QHBoxLayout(this);
 
@@ -692,12 +613,10 @@ void QmitkStdMultiWidget::changeLayoutToDefault()
   m_SubSplit2->addWidget(mitkWidget4Container);
 
   // set splitter Size
-  QList<int> splitterSize;
-  splitterSize.push_back(1000);
-  splitterSize.push_back(1000);
-  m_SubSplit1->setSizes(splitterSize);
-  m_SubSplit2->setSizes(splitterSize);
-  m_LayoutSplit->setSizes(splitterSize);
+  const QList<int> half{ 1000, 1000 };
+  m_SubSplit1->setSizes(half);
+  m_SubSplit2->setSizes(half);
+  m_LayoutSplit->setSizes(half);
 
   // show mainSplitt and add to Layout
   m_MainSplit->show();
@@ -711,27 +630,11 @@ void QmitkStdMultiWidget::changeLayoutToDefault()
     mitkWidget3->show();
   if (mitkWidget4->isHidden())
     mitkWidget4->show();
-
-  m_Layout = LAYOUT_DEFAULT;
-
-  // update Layout Design List
-  mitkWidget1->LayoutDesignListChanged(LAYOUT_DEFAULT);
-  mitkWidget2->LayoutDesignListChanged(LAYOUT_DEFAULT);
-  mitkWidget3->LayoutDesignListChanged(LAYOUT_DEFAULT);
-  mitkWidget4->LayoutDesignListChanged(LAYOUT_DEFAULT);
-
-  // update Alle Widgets
-  this->UpdateAllWidgets();
 }
 
 void QmitkStdMultiWidget::changeLayoutToBig3D()
 {
   SMW_INFO << "changing layout to big 3D ..." << std::endl;
-
-  // Hide all Menu Widgets
-  this->HideAllWidgetToolbars();
-
-  delete QmitkStdMultiWidgetLayout;
 
   // create Main Layout
   QmitkStdMultiWidgetLayout = new QHBoxLayout(this);
@@ -756,26 +659,12 @@ void QmitkStdMultiWidget::changeLayoutToBig3D()
   if (mitkWidget4->isHidden())
     mitkWidget4->show();
 
-  m_Layout = LAYOUT_BIG_3D;
-
-  // update Layout Design List
-  mitkWidget1->LayoutDesignListChanged(LAYOUT_BIG_3D);
-  mitkWidget2->LayoutDesignListChanged(LAYOUT_BIG_3D);
-  mitkWidget3->LayoutDesignListChanged(LAYOUT_BIG_3D);
-  mitkWidget4->LayoutDesignListChanged(LAYOUT_BIG_3D);
-
-  // update Alle Widgets
-  this->UpdateAllWidgets();
+  mitkWidget4->ChangeFullScreenIcon(true);
 }
 
 void QmitkStdMultiWidget::changeLayoutToWidget1()
 {
   SMW_INFO << "changing layout to big Widget1 ..." << std::endl;
-
-  // Hide all Menu Widgets
-  this->HideAllWidgetToolbars();
-
-  delete QmitkStdMultiWidgetLayout;
 
   // create Main Layout
   QmitkStdMultiWidgetLayout = new QHBoxLayout(this);
@@ -800,26 +689,12 @@ void QmitkStdMultiWidget::changeLayoutToWidget1()
   mitkWidget3->hide();
   mitkWidget4->hide();
 
-  m_Layout = LAYOUT_WIDGET1;
-
-  // update Layout Design List
-  mitkWidget1->LayoutDesignListChanged(LAYOUT_WIDGET1);
-  mitkWidget2->LayoutDesignListChanged(LAYOUT_WIDGET1);
-  mitkWidget3->LayoutDesignListChanged(LAYOUT_WIDGET1);
-  mitkWidget4->LayoutDesignListChanged(LAYOUT_WIDGET1);
-
-  // update Alle Widgets
-  this->UpdateAllWidgets();
+  mitkWidget1->ChangeFullScreenIcon(true);
 }
 
 void QmitkStdMultiWidget::changeLayoutToWidget2()
 {
   SMW_INFO << "changing layout to big Widget2 ..." << std::endl;
-
-  // Hide all Menu Widgets
-  this->HideAllWidgetToolbars();
-
-  delete QmitkStdMultiWidgetLayout;
 
   // create Main Layout
   QmitkStdMultiWidgetLayout = new QHBoxLayout(this);
@@ -844,26 +719,12 @@ void QmitkStdMultiWidget::changeLayoutToWidget2()
   mitkWidget3->hide();
   mitkWidget4->hide();
 
-  m_Layout = LAYOUT_WIDGET2;
-
-  // update Layout Design List
-  mitkWidget1->LayoutDesignListChanged(LAYOUT_WIDGET2);
-  mitkWidget2->LayoutDesignListChanged(LAYOUT_WIDGET2);
-  mitkWidget3->LayoutDesignListChanged(LAYOUT_WIDGET2);
-  mitkWidget4->LayoutDesignListChanged(LAYOUT_WIDGET2);
-
-  // update Alle Widgets
-  this->UpdateAllWidgets();
+  mitkWidget2->ChangeFullScreenIcon(true);
 }
 
 void QmitkStdMultiWidget::changeLayoutToWidget3()
 {
   SMW_INFO << "changing layout to big Widget3 ..." << std::endl;
-
-  // Hide all Menu Widgets
-  this->HideAllWidgetToolbars();
-
-  delete QmitkStdMultiWidgetLayout;
 
   // create Main Layout
   QmitkStdMultiWidgetLayout = new QHBoxLayout(this);
@@ -888,26 +749,12 @@ void QmitkStdMultiWidget::changeLayoutToWidget3()
     mitkWidget3->show();
   mitkWidget4->hide();
 
-  m_Layout = LAYOUT_WIDGET3;
-
-  // update Layout Design List
-  mitkWidget1->LayoutDesignListChanged(LAYOUT_WIDGET3);
-  mitkWidget2->LayoutDesignListChanged(LAYOUT_WIDGET3);
-  mitkWidget3->LayoutDesignListChanged(LAYOUT_WIDGET3);
-  mitkWidget4->LayoutDesignListChanged(LAYOUT_WIDGET3);
-
-  // update Alle Widgets
-  this->UpdateAllWidgets();
+  mitkWidget3->ChangeFullScreenIcon(true);
 }
 
 void QmitkStdMultiWidget::changeLayoutToRowWidget3And4()
 {
   SMW_INFO << "changing layout to Widget3 and 4 in a Row..." << std::endl;
-
-  // Hide all Menu Widgets
-  this->HideAllWidgetToolbars();
-
-  delete QmitkStdMultiWidgetLayout;
 
   // create Main Layout
   QmitkStdMultiWidgetLayout = new QHBoxLayout(this);
@@ -928,10 +775,8 @@ void QmitkStdMultiWidget::changeLayoutToRowWidget3And4()
   m_LayoutSplit->addWidget(mitkWidget4Container);
 
   // set Splitter Size
-  QList<int> splitterSize;
-  splitterSize.push_back(1000);
-  splitterSize.push_back(1000);
-  m_LayoutSplit->setSizes(splitterSize);
+  const QList<int> half{ 1000, 1000 };
+  m_LayoutSplit->setSizes(half);
 
   // show mainSplitt and add to Layout
   m_MainSplit->show();
@@ -943,27 +788,11 @@ void QmitkStdMultiWidget::changeLayoutToRowWidget3And4()
     mitkWidget3->show();
   if (mitkWidget4->isHidden())
     mitkWidget4->show();
-
-  m_Layout = LAYOUT_ROW_WIDGET_3_AND_4;
-
-  // update Layout Design List
-  mitkWidget1->LayoutDesignListChanged(LAYOUT_ROW_WIDGET_3_AND_4);
-  mitkWidget2->LayoutDesignListChanged(LAYOUT_ROW_WIDGET_3_AND_4);
-  mitkWidget3->LayoutDesignListChanged(LAYOUT_ROW_WIDGET_3_AND_4);
-  mitkWidget4->LayoutDesignListChanged(LAYOUT_ROW_WIDGET_3_AND_4);
-
-  // update Alle Widgets
-  this->UpdateAllWidgets();
 }
 
 void QmitkStdMultiWidget::changeLayoutToColumnWidget3And4()
 {
   SMW_INFO << "changing layout to Widget3 and 4 in one Column..." << std::endl;
-
-  // Hide all Menu Widgets
-  this->HideAllWidgetToolbars();
-
-  delete QmitkStdMultiWidgetLayout;
 
   // create Main Layout
   QmitkStdMultiWidgetLayout = new QHBoxLayout(this);
@@ -984,10 +813,8 @@ void QmitkStdMultiWidget::changeLayoutToColumnWidget3And4()
   m_LayoutSplit->addWidget(mitkWidget4Container);
 
   // set SplitterSize
-  QList<int> splitterSize;
-  splitterSize.push_back(1000);
-  splitterSize.push_back(1000);
-  m_LayoutSplit->setSizes(splitterSize);
+  const QList<int> half{ 1000, 1000 };
+  m_LayoutSplit->setSizes(half);
 
   // show mainSplitt and add to Layout
   m_MainSplit->show();
@@ -999,17 +826,6 @@ void QmitkStdMultiWidget::changeLayoutToColumnWidget3And4()
     mitkWidget3->show();
   if (mitkWidget4->isHidden())
     mitkWidget4->show();
-
-  m_Layout = LAYOUT_COLUMN_WIDGET_3_AND_4;
-
-  // update Layout Design List
-  mitkWidget1->LayoutDesignListChanged(LAYOUT_COLUMN_WIDGET_3_AND_4);
-  mitkWidget2->LayoutDesignListChanged(LAYOUT_COLUMN_WIDGET_3_AND_4);
-  mitkWidget3->LayoutDesignListChanged(LAYOUT_COLUMN_WIDGET_3_AND_4);
-  mitkWidget4->LayoutDesignListChanged(LAYOUT_COLUMN_WIDGET_3_AND_4);
-
-  // update Alle Widgets
-  this->UpdateAllWidgets();
 }
 
 void QmitkStdMultiWidget::changeLayoutToRowWidgetSmall3andBig4()
@@ -1017,18 +833,11 @@ void QmitkStdMultiWidget::changeLayoutToRowWidgetSmall3andBig4()
   SMW_INFO << "changing layout to Widget3 and 4 in a Row..." << std::endl;
 
   this->changeLayoutToRowWidget3And4();
-
-  m_Layout = LAYOUT_ROW_WIDGET_SMALL3_AND_BIG4;
 }
 
 void QmitkStdMultiWidget::changeLayoutToSmallUpperWidget2Big3and4()
 {
   SMW_INFO << "changing layout to Widget3 and 4 in a Row..." << std::endl;
-
-  // Hide all Menu Widgets
-  this->HideAllWidgetToolbars();
-
-  delete QmitkStdMultiWidgetLayout;
 
   // create Main Layout
   QmitkStdMultiWidgetLayout = new QHBoxLayout(this);
@@ -1055,13 +864,9 @@ void QmitkStdMultiWidget::changeLayoutToSmallUpperWidget2Big3and4()
   m_SubSplit2->addWidget(mitkWidget4Container);
 
   // set Splitter Size
-  QList<int> splitterSize;
-  splitterSize.push_back(1000);
-  splitterSize.push_back(1000);
-  m_SubSplit2->setSizes(splitterSize);
-  splitterSize.clear();
-  splitterSize.push_back(500);
-  splitterSize.push_back(1000);
+  const QList<int> half{ 1000, 1000 };
+  m_SubSplit2->setSizes(half);
+  const QList<int> splitterSize{ 500, 1000 };
   m_LayoutSplit->setSizes(splitterSize);
 
   // show mainSplitt
@@ -1075,27 +880,11 @@ void QmitkStdMultiWidget::changeLayoutToSmallUpperWidget2Big3and4()
     mitkWidget3->show();
   if (mitkWidget4->isHidden())
     mitkWidget4->show();
-
-  m_Layout = LAYOUT_SMALL_UPPER_WIDGET2_BIG3_AND4;
-
-  // update Layout Design List
-  mitkWidget1->LayoutDesignListChanged(LAYOUT_SMALL_UPPER_WIDGET2_BIG3_AND4);
-  mitkWidget2->LayoutDesignListChanged(LAYOUT_SMALL_UPPER_WIDGET2_BIG3_AND4);
-  mitkWidget3->LayoutDesignListChanged(LAYOUT_SMALL_UPPER_WIDGET2_BIG3_AND4);
-  mitkWidget4->LayoutDesignListChanged(LAYOUT_SMALL_UPPER_WIDGET2_BIG3_AND4);
-
-  // update Alle Widgets
-  this->UpdateAllWidgets();
 }
 
 void QmitkStdMultiWidget::changeLayoutTo2x2Dand3DWidget()
 {
   SMW_INFO << "changing layout to 2 x 2D and 3D Widget" << std::endl;
-
-  // Hide all Menu Widgets
-  this->HideAllWidgetToolbars();
-
-  delete QmitkStdMultiWidgetLayout;
 
   // create Main Layout
   QmitkStdMultiWidgetLayout = new QHBoxLayout(this);
@@ -1121,11 +910,9 @@ void QmitkStdMultiWidget::changeLayoutTo2x2Dand3DWidget()
   m_SubSplit2->addWidget(mitkWidget4Container);
 
   // set Splitter Size
-  QList<int> splitterSize;
-  splitterSize.push_back(1000);
-  splitterSize.push_back(1000);
-  m_SubSplit1->setSizes(splitterSize);
-  m_LayoutSplit->setSizes(splitterSize);
+  const QList<int> half{ 1000, 1000 };
+  m_SubSplit1->setSizes(half);
+  m_LayoutSplit->setSizes(half);
 
   // show mainSplitt and add to Layout
   m_MainSplit->show();
@@ -1138,27 +925,11 @@ void QmitkStdMultiWidget::changeLayoutTo2x2Dand3DWidget()
   mitkWidget3->hide();
   if (mitkWidget4->isHidden())
     mitkWidget4->show();
-
-  m_Layout = LAYOUT_2X_2D_AND_3D_WIDGET;
-
-  // update Layout Design List
-  mitkWidget1->LayoutDesignListChanged(LAYOUT_2X_2D_AND_3D_WIDGET);
-  mitkWidget2->LayoutDesignListChanged(LAYOUT_2X_2D_AND_3D_WIDGET);
-  mitkWidget3->LayoutDesignListChanged(LAYOUT_2X_2D_AND_3D_WIDGET);
-  mitkWidget4->LayoutDesignListChanged(LAYOUT_2X_2D_AND_3D_WIDGET);
-
-  // update Alle Widgets
-  this->UpdateAllWidgets();
 }
 
 void QmitkStdMultiWidget::changeLayoutToLeft2Dand3DRight2D()
 {
   SMW_INFO << "changing layout to 2D and 3D left, 2D right Widget" << std::endl;
-
-  // Hide all Menu Widgets
-  this->HideAllWidgetToolbars();
-
-  delete QmitkStdMultiWidgetLayout;
 
   // create Main Layout
   QmitkStdMultiWidgetLayout = new QHBoxLayout(this);
@@ -1184,11 +955,9 @@ void QmitkStdMultiWidget::changeLayoutToLeft2Dand3DRight2D()
   m_SubSplit2->addWidget(mitkWidget2Container);
 
   // set Splitter Size
-  QList<int> splitterSize;
-  splitterSize.push_back(1000);
-  splitterSize.push_back(1000);
-  m_SubSplit1->setSizes(splitterSize);
-  m_LayoutSplit->setSizes(splitterSize);
+  const QList<int> half{ 1000, 1000 };
+  m_SubSplit1->setSizes(half);
+  m_LayoutSplit->setSizes(half);
 
   // show mainSplitt and add to Layout
   m_MainSplit->show();
@@ -1201,27 +970,11 @@ void QmitkStdMultiWidget::changeLayoutToLeft2Dand3DRight2D()
   mitkWidget3->hide();
   if (mitkWidget4->isHidden())
     mitkWidget4->show();
-
-  m_Layout = LAYOUT_2D_AND_3D_LEFT_2D_RIGHT_WIDGET;
-
-  // update Layout Design List
-  mitkWidget1->LayoutDesignListChanged(LAYOUT_2D_AND_3D_LEFT_2D_RIGHT_WIDGET);
-  mitkWidget2->LayoutDesignListChanged(LAYOUT_2D_AND_3D_LEFT_2D_RIGHT_WIDGET);
-  mitkWidget3->LayoutDesignListChanged(LAYOUT_2D_AND_3D_LEFT_2D_RIGHT_WIDGET);
-  mitkWidget4->LayoutDesignListChanged(LAYOUT_2D_AND_3D_LEFT_2D_RIGHT_WIDGET);
-
-  // update Alle Widgets
-  this->UpdateAllWidgets();
 }
 
 void QmitkStdMultiWidget::changeLayoutTo2DUpAnd3DDown()
 {
   SMW_INFO << "changing layout to 2D up and 3D down" << std::endl;
-
-  // Hide all Menu Widgets
-  this->HideAllWidgetToolbars();
-
-  delete QmitkStdMultiWidgetLayout;
 
   // create Main Layout
   QmitkStdMultiWidgetLayout = new QHBoxLayout(this);
@@ -1247,15 +1000,12 @@ void QmitkStdMultiWidget::changeLayoutTo2DUpAnd3DDown()
   // insert Widget Container into splitter top
   m_SubSplit1->addWidget(mitkWidget1Container);
 
-  // set SplitterSize for splitter top
-  QList<int> splitterSize;
   // insert Widget Container into splitter bottom
   m_SubSplit2->addWidget(mitkWidget4Container);
+
   // set SplitterSize for splitter m_LayoutSplit
-  splitterSize.clear();
-  splitterSize.push_back(700);
-  splitterSize.push_back(700);
-  m_LayoutSplit->setSizes(splitterSize);
+  const QList<int> half{ 700, 700 };
+  m_LayoutSplit->setSizes(half);
 
   // show mainSplitt
   m_MainSplit->show();
@@ -1267,17 +1017,6 @@ void QmitkStdMultiWidget::changeLayoutTo2DUpAnd3DDown()
   mitkWidget3->hide();
   if (mitkWidget4->isHidden())
     mitkWidget4->show();
-
-  m_Layout = LAYOUT_2D_UP_AND_3D_DOWN;
-
-  // update Layout Design List
-  mitkWidget1->LayoutDesignListChanged(LAYOUT_2D_UP_AND_3D_DOWN);
-  mitkWidget2->LayoutDesignListChanged(LAYOUT_2D_UP_AND_3D_DOWN);
-  mitkWidget3->LayoutDesignListChanged(LAYOUT_2D_UP_AND_3D_DOWN);
-  mitkWidget4->LayoutDesignListChanged(LAYOUT_2D_UP_AND_3D_DOWN);
-
-  // update all Widgets
-  this->UpdateAllWidgets();
 }
 
 void QmitkStdMultiWidget::SetDataStorage(mitk::DataStorage *ds)
@@ -1814,6 +1553,7 @@ void QmitkStdMultiWidget::SetWidgetPlaneModeToSwivel(bool activate)
 
 void QmitkStdMultiWidget::OnLayoutDesignChanged(int layoutDesignIndex)
 {
+  ClearWidgetsForNewLayout();
   switch (layoutDesignIndex)
   {
     case LAYOUT_DEFAULT:
@@ -1882,6 +1622,56 @@ void QmitkStdMultiWidget::OnLayoutDesignChanged(int layoutDesignIndex)
       break;
     }
   };
+
+  m_Layout = layoutDesignIndex;
+  mitkWidget1->LayoutDesignListChanged(layoutDesignIndex);
+  mitkWidget2->LayoutDesignListChanged(layoutDesignIndex);
+  mitkWidget3->LayoutDesignListChanged(layoutDesignIndex);
+  mitkWidget4->LayoutDesignListChanged(layoutDesignIndex);
+
+  this->UpdateAllWidgets();
+}
+
+void QmitkStdMultiWidget::ClearWidgetsForNewLayout()
+{
+  // We must clean all the splitters and linked widgets or we have UI
+  // problems on OS X.
+  delete QmitkStdMultiWidgetLayout;
+  if (m_SubSplit1)
+  {
+    m_SubSplit1->deleteLater();
+    m_SubSplit1 = nullptr;
+  }
+  if (m_SubSplit2)
+  {
+    m_SubSplit2->deleteLater();
+    m_SubSplit2 = nullptr;
+  }
+  if (m_LayoutSplit)
+  {
+    m_LayoutSplit->deleteLater();
+    m_LayoutSplit = nullptr;
+  }
+  if (m_MainSplit)
+  {
+    m_MainSplit->deleteLater();
+    m_MainSplit = nullptr;
+  }
+
+  mitkWidget1Container->setParent(nullptr);
+  mitkWidget2Container->setParent(nullptr);
+  mitkWidget3Container->setParent(nullptr);
+  mitkWidget4Container->setParent(nullptr);
+
+  mitkWidget1->HideMenu();
+  mitkWidget1->ChangeFullScreenIcon(false);
+  mitkWidget2->HideMenu();
+  mitkWidget2->ChangeFullScreenIcon(false);
+  mitkWidget3->HideMenu();
+  mitkWidget3->ChangeFullScreenIcon(false);
+  mitkWidget4->HideMenu();
+  mitkWidget4->ChangeFullScreenIcon(false);
+
 }
 
 void QmitkStdMultiWidget::UpdateAllWidgets()
@@ -1897,14 +1687,6 @@ void QmitkStdMultiWidget::UpdateAllWidgets()
 
   mitkWidget4->resize(mitkWidget4Container->frameSize().width() - 1, mitkWidget4Container->frameSize().height());
   mitkWidget4->resize(mitkWidget4Container->frameSize().width(), mitkWidget4Container->frameSize().height());
-}
-
-void QmitkStdMultiWidget::HideAllWidgetToolbars()
-{
-  mitkWidget1->HideRenderWindowMenu();
-  mitkWidget2->HideRenderWindowMenu();
-  mitkWidget3->HideRenderWindowMenu();
-  mitkWidget4->HideRenderWindowMenu();
 }
 
 void QmitkStdMultiWidget::ActivateMenuWidget(bool state)


### PR DESCRIPTION
The menus were ok at the start but they had some visual glitches once we went fullscreen once. It was happening on Windows and Linux too but only on 2016.03. It was broken on master only for OS X.

I tried to fix the menus visibility and fullscreen icons while keeping the rest in good state. I wasn't able to make the menu appears again after a click on an action. Well, I was able but not on all OS so I simply deactived it. The user needs to move the mouse a bit and the menu will appear again.

Tested on Windows and OS X 10.11. I know it compiles on Linux but I was testing on a VM without gpu drivers so it would be nice of someone can test.

While working on this task, I took the liberty to clean the **related** code a bit. Mostly unused and deprecated methods. I believe I didn't went crazy with your codebase :) and the code is simpler now.