### PR TITLE
T22211: Potential crash in statistics calculator

### DIFF
--- a/Modules/ImageStatistics/mitkImageStatisticsCalculator.h
+++ b/Modules/ImageStatistics/mitkImageStatisticsCalculator.h
@@ -396,7 +396,12 @@ namespace mitk
     * corresponding to the PlanarFigure will be extracted from the original
     * image. If masking is disabled, the original image is simply passed
     * through. */
-    void ExtractImageAndMask( unsigned int timeStep = 0 );
+    void ExtractImageAndMask(
+      unsigned int timeStep, 
+      mitk::Image::ConstPointer& internalImage,
+      MaskImage3DType::Pointer& internalImageMask3D,
+      MaskImage2DType::Pointer& internalImageMask2D
+    );
 
     /*calculate the min and max value, this is done because we need the min and max value before execution the statistics filter to have the wright range for the histogramm*/
     template < typename TPixel, unsigned int VImageDimension >
@@ -424,7 +429,7 @@ namespace mitk
 
     template < typename TPixel, unsigned int VImageDimension >
     void InternalCalculateMaskFromPlanarFigure(
-      const itk::Image< TPixel, VImageDimension > *image, unsigned int axis );
+      const itk::Image< TPixel, VImageDimension > *image, unsigned int axis, MaskImage2DType::Pointer& internalImageMask2D);
 
     template < typename TPixel, unsigned int VImageDimension >
     void InternalMaskIgnoredPixels(
@@ -565,11 +570,6 @@ namespace mitk
 
     unsigned int m_MaskingMode;
     bool m_MaskingModeChanged;
-
-    /** m_InternalImage contains a image volume at one time step (e.g. 2D, 3D)*/
-    mitk::Image::ConstPointer m_InternalImage;
-    MaskImage3DType::Pointer m_InternalImageMask3D;
-    MaskImage2DType::Pointer m_InternalImageMask2D;
 
     TimeStampVectorType m_ImageStatisticsTimeStampVector;
     TimeStampVectorType m_MaskedImageStatisticsTimeStampVector;


### PR DESCRIPTION
Problem is in smart pointers in calculator's members and in thrown exception.

Calculator contains two smart pointers to images: m_Image and m_InternalImage that is actually points to some slice from m_Image.
m_InternalImage is initialized in ImageStatisticsCalculator::ComputeStatistics() (inside ExtractImageAndMask()) and is cleared at the end of this function.
But if there is an exception in ExtractImageAndMask() (for example, if we calculate statistics for planar figure that is outside of image's boundaries), m_InternalImage isn't cleared at the end and still points to some slice. So far so good.

Later, when you set up new image to calculator, old image from m_Image is deleted but its ImageData isn't because m_InternalImage data holds it as parent. And of course m_InternalImage still exists at this point.
Later, ExtractImageAndMask() is called, m_InternalImage is rewritten, old image from it is deleted, image data from old m_Image is also deleted and deletes its own ImageVtkWriteAccessor. Which tries to access old m_Image that was deleted some time ago. And there is a crash.

In this PR I've moved m_InternalImage from member to local variable, so it will be released even in case of exception.

Signed-off-by: KuznetsovAlexander <KuznetsovAlexander@rambler.ru>