### PR TITLE
Fixed coordinate difference in region growing

### DIFF
--- a/Modules/Segmentation/Interactions/mitkRegionGrowingTool.cpp
+++ b/Modules/Segmentation/Interactions/mitkRegionGrowingTool.cpp
@@ -637,5 +637,8 @@ void mitk::RegionGrowingTool::OnMouseReleased(StateMachineAction *, InteractionE
       this->WriteBackSegmentationResult(positionEvent, m_WorkingSlice);
       FeedbackContourTool::SetFeedbackContourVisible(false);
     }
+
+    m_ScreenYDifference = 0;
+    m_ScreenXDifference = 0;
   }
 }


### PR DESCRIPTION
This problem is described in https://phabricator.mitk.org/T22494

There is a problem in region growing: screen difference coordinates are modified on mouse moving but they are never reset:
    m_ScreenYDifference += positionEvent->GetPointerPositionOnScreen()[1] - m_LastScreenPosition[1];
    m_ScreenXDifference += positionEvent->GetPointerPositionOnScreen()[0] - m_LastScreenPosition[0];

This leads to problems after several tool usages.
If you always move mouse in one direction when selecting several regions with region growing, m_ScreenYDifference and m_ScreenXDifference become huge, thresholds for tool become huge, too, and tool works incorrectly.

I've added coordinate difference reset on mouse button release.

Signed-off-by: KuznetsovAlexander <KuznetsovAlexander@rambler.ru>