### PR TITLE
Compatibility with old scene files broken (Surface line width redefined from int to float)

### DIFF
--- a/Modules/Core/include/mitkSurfaceVtkMapper2D.h
+++ b/Modules/Core/include/mitkSurfaceVtkMapper2D.h
@@ -189,6 +189,19 @@ namespace mitk
     virtual void ResetMapper(BaseRenderer *renderer) override;
 
     /**
+     * @brief Updates legacy properties to current behavior/interpretation.
+     * @param renderer The respective renderer of the mitkRenderWindow.
+     *
+     * Whenever a mapper decides to change its property types or its
+     * interpretation of certain values, it should add something to this
+     * method and call it before methods like ApplyProperties();
+     *
+     * This is particularly helpful when dealing with data from
+     * archive/scene files that were created before changes.
+     */
+    virtual void FixupLegacyProperties(PropertyList* properties);
+
+    /**
        * @brief ApplyAllProperties Pass all the properties to VTK.
        * @param renderer The respective renderer of the mitkRenderWindow.
        */

--- a/Modules/Core/src/Rendering/mitkSurfaceVtkMapper2D.cpp
+++ b/Modules/Core/src/Rendering/mitkSurfaceVtkMapper2D.cpp
@@ -16,7 +16,7 @@ See LICENSE.txt or http://www.mitk.org for details.
 
 #include "mitkSurfaceVtkMapper2D.h"
 
-// mitk includes
+// MITK includes
 #include "mitkVtkPropRenderer.h"
 #include <mitkCoreServices.h>
 #include <mitkDataNode.h>
@@ -28,7 +28,7 @@ See LICENSE.txt or http://www.mitk.org for details.
 #include <mitkTransferFunctionProperty.h>
 #include <mitkVtkScalarModeProperty.h>
 
-// vtk includes
+// VTK includes
 #include <vtkActor.h>
 #include <vtkArrowSource.h>
 #include <vtkAssembly.h>
@@ -262,14 +262,30 @@ void mitk::SurfaceVtkMapper2D::GenerateDataForRenderer(mitk::BaseRenderer *rende
   }
 }
 
-void mitk::SurfaceVtkMapper2D::ApplyAllProperties(mitk::BaseRenderer *renderer)
+void mitk::SurfaceVtkMapper2D::FixupLegacyProperties(PropertyList* properties)
 {
-  const DataNode *node = GetDataNode();
+  // Before bug 18528, "line width" was an IntProperty, now it is a FloatProperty
+  float lineWidth = 1.0f;
+  if ( !properties->GetFloatProperty("line width", lineWidth) )
+  {
+    int legacyLineWidth = lineWidth;
+    if ( properties->GetIntProperty("line width", legacyLineWidth) )
+    {
+      properties->ReplaceProperty("line width", FloatProperty::New(static_cast<float>(legacyLineWidth)));
+    }
+  }
+}
+
+void mitk::SurfaceVtkMapper2D::ApplyAllProperties(mitk::BaseRenderer* renderer)
+{
+  const DataNode * node = GetDataNode();
 
   if (node == NULL)
   {
     return;
   }
+
+  FixupLegacyProperties(node->GetPropertyList(renderer));
 
   float lineWidth = 1.0f;
   node->GetFloatProperty("line width", lineWidth, renderer);


### PR DESCRIPTION
See https://phabricator.mitk.org/T19360

Surface's "line width" property has been an IntProperty since the beginning.
Since December 2014, T18528 (Hackfest: make Core OpenGL free), this property has been redefined to a float value.

This change is very welcome, but it breaks compatibility with older scene files that stored an int value.

Signed-off-by: Daniel Maleike <code@maleike.de>