### PR TITLE
Fix crosshair rotation cursor

### DIFF
--- a/Modules/Core/resource/Interactions/DisplayInteraction.xml
+++ b/Modules/Core/resource/Interactions/DisplayInteraction.xml
@@ -114,6 +114,9 @@ TODO Std move to abort interaction of scroll/pan/zoom
       <transition event_class="InteractionPositionEvent" event_variant="StartRotate" target="rotation">
         <action name="rotate"/>
       </transition>
+	  <transition event_class="InternalEvent" event_variant="LeaveRenderWindow" target="start">
+		 <action name="endRotation"/>
+	  </transition>
       <transition event_class="InteractionPositionEvent" event_variant="Move" target="start">
         <condition name="check_can_rotate" inverted="true" />
         <action name="endRotation"/>


### PR DESCRIPTION
This commit fixes 2 bugs:
- Stuck in crosshair rotation, as explained in T22464.
- Stuck with the wrong cursor, if you move your cursor following an
axis out of the render window, the cursor doesn't revert to the
standard cursor, so you can have a rotation cursor in the 3D view,
in the datamanager, etc.

Signed-off-by: Nil Goyette <nil.goyette@imeka.ca>