### PR TITLE
Fix the crosshair rotation zone

### DIFF
--- a/Modules/Core/src/Interactions/mitkDisplayInteractor.cpp
+++ b/Modules/Core/src/Interactions/mitkDisplayInteractor.cpp
@@ -142,6 +142,7 @@ bool mitk::DisplayInteractor::CheckRotationPossible(const mitk::InteractionEvent
     return false;
 
   Point3D cursorPosition = posEvent->GetPositionInWorld();
+  const auto spacing = ourViewportGeometry->GetSpacing();
   const PlaneGeometry *geometryToBeRotated = NULL; // this one is under the mouse cursor
   const PlaneGeometry *anyOtherGeometry = NULL;    // this is also visible (for calculation of intersection ONLY)
   Line3D intersectionLineWithGeometryToBeRotated;
@@ -173,7 +174,8 @@ bool mitk::DisplayInteractor::CheckRotationPossible(const mitk::InteractionEvent
     }
 
     // check distance from intersection line
-    double distanceFromIntersectionLine = intersectionLine.Distance(cursorPosition);
+    const double distanceFromIntersectionLine =
+      intersectionLine.Distance(cursorPosition) / spacing[snc->GetDefaultViewDirection()];
 
     // far away line, only remember for linked rotation if necessary
     if (distanceFromIntersectionLine > threshholdDistancePixels)


### PR DESCRIPTION
The rotation zone is a clean cross only for image with a standard
spacing such as (1.0, 1.0, 1.0) or near. A bigger spacing reduces
the zone's width. A smaller spacing makes the zone bigger and farther,
which can make the rotation unusable.

Signed-off-by: Nil Goyette nil.goyette@imeka.ca