### PR TITLE
Fix conversion of raw C strings to QStrings - allowing less special c…

### DIFF
--- a/Modules/QtWidgets/src/QmitkDataStorageTableModel.cpp
+++ b/Modules/QtWidgets/src/QmitkDataStorageTableModel.cpp
@@ -146,7 +146,7 @@ QVariant QmitkDataStorageTableModel::data(const QModelIndex &index, int role) co
       // get name of node (may also be edited)
       if (role == Qt::DisplayRole || role == Qt::EditRole)
       {
-        data = QFile::encodeName(nodeName.c_str());
+        data = QString::fromStdString(nodeName);
       }
       else if (role == QmitkDataNodeRole)
       {

--- a/Modules/QtWidgets/src/QmitkDataStorageTreeModel.cpp
+++ b/Modules/QtWidgets/src/QmitkDataStorageTreeModel.cpp
@@ -446,20 +446,20 @@ QVariant QmitkDataStorageTreeModel::data(const QModelIndex &index, int role) con
 
     if (patientsName)
     {
-      nodeName += QFile::encodeName(patientsName->GetValueAsString().c_str()) + "\n";
-      nodeName += QFile::encodeName(studyDescription->GetValueAsString().c_str()) + "\n";
-      nodeName += QFile::encodeName(seriesDescription->GetValueAsString().c_str());
+      nodeName += QString::fromStdString(patientsName->GetValueAsString()) + "\n";
+      nodeName += QString::fromStdString(studyDescription->GetValueAsString()) + "\n";
+      nodeName += QString::fromStdString(seriesDescription->GetValueAsString());
     }
     else
     { /** Code coveres the deprecated property naming for backwards compatibility */
-      nodeName += QFile::encodeName(patientsName_deprecated->GetValueAsString().c_str()) + "\n";
-      nodeName += QFile::encodeName(studyDescription_deprecated->GetValueAsString().c_str()) + "\n";
-      nodeName += QFile::encodeName(seriesDescription_deprecated->GetValueAsString().c_str());
+      nodeName += QString::fromStdString(patientsName_deprecated->GetValueAsString()) + "\n";
+      nodeName += QString::fromStdString(studyDescription_deprecated->GetValueAsString()) + "\n";
+      nodeName += QString::fromStdString(seriesDescription_deprecated->GetValueAsString());
     }
   }
   else
   {
-    nodeName = QFile::encodeName(dataNode->GetName().c_str());
+    nodeName = QString::fromStdString(dataNode->GetName());
   }
   if (nodeName.isEmpty())
   {

--- a/Modules/QtWidgets/src/QmitkIOUtil.cpp
+++ b/Modules/QtWidgets/src/QmitkIOUtil.cpp
@@ -119,7 +119,7 @@ QList<mitk::BaseData::Pointer> QmitkIOUtil::Load(const QStringList &paths, QWidg
   std::vector<LoadInfo> loadInfos;
   foreach (const QString &file, paths)
   {
-    loadInfos.push_back(LoadInfo(file.toStdString()));
+    loadInfos.push_back(LoadInfo(file.toLocal8Bit().constData()));
   }
 
   Impl::ReaderOptionsDialogFunctor optionsCallback;
@@ -149,7 +149,7 @@ mitk::DataStorage::SetOfObjects::Pointer QmitkIOUtil::Load(const QStringList &pa
   std::vector<LoadInfo> loadInfos;
   foreach (const QString &file, paths)
   {
-    loadInfos.push_back(LoadInfo(QFile::encodeName(file).constData()));
+    loadInfos.push_back(LoadInfo(file.toLocal8Bit().constData()));
   }
 
   mitk::DataStorage::SetOfObjects::Pointer nodeResult = mitk::DataStorage::SetOfObjects::New();
@@ -251,7 +251,7 @@ QStringList QmitkIOUtil::Save(const std::vector<const mitk::BaseData *> &data,
     }
 
     fileName = nextName;
-    std::string stdFileName = QFile::encodeName(fileName).constData();
+    std::string stdFileName = fileName.toLocal8Bit().constData();
     QFileInfo fileInfo(fileName);
     currentPath = fileInfo.absolutePath();
     QString suffix = fileInfo.completeSuffix();
@@ -310,7 +310,7 @@ QStringList QmitkIOUtil::Save(const std::vector<const mitk::BaseData *> &data,
         {
           suffix = QString::fromStdString(selectedMimeType.GetExtensions().front());
           fileName += "." + suffix;
-          stdFileName = QFile::encodeName(fileName).constData();
+          stdFileName = fileName.toLocal8Bit().constData();
           // We changed the file name (added a suffix) so ask in case
           // the file aready exists.
           fileInfo = QFileInfo(fileName);


### PR DESCRIPTION
Since an update to MITK 2016.11 I cannot use special characters such as 'ä' or 'ß' when editing the name of a DataNode in Data Manager's tree view (via a double-click on the item or by pressing F2 when an item is selected). The in-place editor displays the correct characters, but they are not correctly transfered to the real node name (std::string). When the editor is closed, the characters are replaced by "missing character" symbols.

The reason seems to be a conversion of std::string to QString via QFile::encodeName() which is uses at least since https://phabricator.mitk.org/rMITK2a228d18dbe1e77560012e90954960690b953292
When I replace QFile::encodeName() by the more current QString::fromStdString() everything works fine for me.

Unless there is a good reason why QFile::encodeName() needs to be used, I suggest replacing it by QString::fromStdString().