### PR TITLE
Nodes are inserted in data manager at position according to their layer

### DIFF
--- a/Modules/QtWidgets/src/QmitkDataStorageTreeModel.cpp
+++ b/Modules/QtWidgets/src/QmitkDataStorageTreeModel.cpp
@@ -636,14 +636,33 @@ void QmitkDataStorageTreeModel::AddNodeInternal(const mitk::DataNode *node)
   }
   else
   {
-    beginInsertRows(index, parentTreeItem->GetChildCount(), parentTreeItem->GetChildCount());
-    new TreeItem(const_cast<mitk::DataNode *>(node), parentTreeItem);
+    int firstRowWithASiblingBelow = 0;
+    int nodeLayer = -1;
+    node->GetIntProperty("layer", nodeLayer);
+    for (TreeItem* siblingTreeItem: parentTreeItem->GetChildren())
+    {
+      int siblingLayer = -1;
+      if (mitk::DataNode* siblingNode = siblingTreeItem->GetDataNode())
+      {
+        siblingNode->GetIntProperty("layer", siblingLayer);
+      }
+      if (nodeLayer > siblingLayer)
+      {
+        break;
+      }
+      ++firstRowWithASiblingBelow;
+    }
+    beginInsertRows(index, firstRowWithASiblingBelow, firstRowWithASiblingBelow);
+    parentTreeItem->InsertChild(new TreeItem(const_cast<mitk::DataNode*>(node)), firstRowWithASiblingBelow);
   }
 
   // emit endInsertRows event
   endInsertRows();
 
-  this->AdjustLayerProperty();
+  if(m_PlaceNewNodesOnTop)
+  {
+    this->AdjustLayerProperty();
+  }
 }
 
 void QmitkDataStorageTreeModel::AddNode(const mitk::DataNode *node)
@@ -991,16 +1010,22 @@ void QmitkDataStorageTreeModel::Update()
 {
   if (m_DataStorage.IsNotNull())
   {
-    this->beginResetModel();
-    this->endResetModel();
-
     mitk::DataStorage::SetOfObjects::ConstPointer _NodeSet = m_DataStorage->GetAll();
 
-    for (mitk::DataStorage::SetOfObjects::const_iterator it = _NodeSet->begin(); it != _NodeSet->end(); it++)
+    /// Regardless the value of this preference, the new nodes must not be inserted
+    /// at the top now, but at the position according to their layer.
+    bool newNodesWereToBePlacedOnTop = m_PlaceNewNodesOnTop;
+    m_PlaceNewNodesOnTop = false;
+
+    for (const auto& node: *_NodeSet)
     {
-      // save node
-      this->AddNodeInternal(*it);
+      this->AddNodeInternal(node);
     }
+
+    m_PlaceNewNodesOnTop = newNodesWereToBePlacedOnTop;
+
+    /// Adjust the layers to ensure that derived nodes are above their sources.
+    this->AdjustLayerProperty();
   }
 }
 

--- a/Plugins/org.mitk.gui.qt.datamanager/src/QmitkDataManagerView.cpp
+++ b/Plugins/org.mitk.gui.qt.datamanager/src/QmitkDataManagerView.cpp
@@ -122,10 +122,8 @@ void QmitkDataManagerView::CreateQtPartControl(QWidget* parent)
       , &QmitkDataManagerView::OnPreferencesChanged ) );
 
   //# GUI
-  m_NodeTreeModel = new QmitkDataStorageTreeModel(this->GetDataStorage());
+  m_NodeTreeModel = new QmitkDataStorageTreeModel(this->GetDataStorage(), prefs->GetBool("Place new nodes on top", true));
   m_NodeTreeModel->setParent( parent );
-  m_NodeTreeModel->SetPlaceNewNodesOnTop(
-      prefs->GetBool("Place new nodes on top", true) );
   m_NodeTreeModel->SetAllowHierarchyChange(
     prefs->GetBool("Allow changing of parent node", false));
   m_SurfaceDecimation = prefs->GetBool("Use surface decimation", false);


### PR DESCRIPTION
When the data manager was initialised from a data storage or when
new data nodes were added, the nodes were added to the top or the
bottom under their source nodes, depending on the value of the
"Place new nodes on top" preference.

Beside this, when the data manager was initialised, the data nodes
were added in the same order in which they appeared in the data
structure retrieved from the data storage. However, in this data
structure the nodes are ordered by their smart pointer what makes
the final order in the data manager indeterministic.

The current commit inserts the nodes at the position according to
their layer, unless the the preference is set, in which case it
inserts the nodes at the top. This is when adding new nodes to the
data storage. When initialising the data manager from a data storage,
the data nodes are always inserted in the order of their layer.
(The preference is temporarily disabled for the time of initialisation.)

Signed-off-by: Miklos Espak <m.espak@ucl.ac.uk>