### PR TITLE
Distinguish between missing help pages and missing help context

### DIFF
--- a/Plugins/org.blueberry.ui.qt.help/src/internal/berryHelpWebView.cpp
+++ b/Plugins/org.blueberry.ui.qt.help/src/internal/berryHelpWebView.cpp
@@ -208,9 +208,13 @@ void HelpUrlSchemeHandler::requestStarted(QWebEngineUrlRequestJob* job)
 }
 
 const QString HelpWebView::m_PageNotFoundMessage =
-    QCoreApplication::translate("org.blueberry.ui.qt.help", "<title>Error 404...</title><div "
-                                "align=\"center\"><br><br><h1>The page could not be found</h1><br><h3>'%1'"
+    QCoreApplication::translate("org.blueberry.ui.qt.help", "<title>Context Help</title><div "
+                                "align=\"center\"><br><br><h1>No help page found for identifier</h1><br><h3>'%1'"
                                 "</h3></div>");
+
+const QString HelpWebView::m_MissingContextMessage =
+    QCoreApplication::translate("org.blueberry.ui.qt.help", "<title>Context Help</title><div "
+                                "align=\"center\"><br><br><h1>Unknown context..</h1><h1>&nbsp;</h1><h1>Please click inside a view and hit F1 again!</h1></div>");
 
 class HelpPage final : public QWebEnginePage
 {
@@ -328,10 +332,17 @@ bool HelpWebView::handleForwardBackwardMouseButtons(QMouseEvent *e)
 
 void HelpWebView::setSource(const QUrl &url)
 {
-  if (m_HelpEngine.findFile(url).isValid())
+  if (url.toString().trimmed().isEmpty()) {
+    setHtml(m_MissingContextMessage.arg(url.toString()));
+  }
+  else if (m_HelpEngine.findFile(url).isValid())
+  {
     load(url);
+  }
   else
+  {
     setHtml(m_PageNotFoundMessage.arg(url.toString()));
+  }
 }
 
 void HelpWebView::wheelEvent(QWheelEvent *e)

--- a/Plugins/org.blueberry.ui.qt.help/src/internal/berryHelpWebView.cpp
+++ b/Plugins/org.blueberry.ui.qt.help/src/internal/berryHelpWebView.cpp
@@ -333,7 +333,7 @@ bool HelpWebView::handleForwardBackwardMouseButtons(QMouseEvent *e)
 void HelpWebView::setSource(const QUrl &url)
 {
   if (url.toString().trimmed().isEmpty()) {
-    setHtml(m_MissingContextMessage.arg(url.toString()));
+    setHtml(m_MissingContextMessage);
   }
   else if (m_HelpEngine.findFile(url).isValid())
   {

--- a/Plugins/org.blueberry.ui.qt.help/src/internal/berryHelpWebView.h
+++ b/Plugins/org.blueberry.ui.qt.help/src/internal/berryHelpWebView.h
@@ -69,6 +69,7 @@ public:
   static bool canOpenPage(const QString &url);
   static bool isLocalUrl(const QUrl &url);
   static bool launchWithExternalApp(const QUrl &url);
+  static const QString m_MissingContextMessage;
   static const QString m_PageNotFoundMessage;
 
 public Q_SLOTS:


### PR DESCRIPTION
Simple fix of the message that is displayed when the context help view does not find the corresponding HTML page.

Distinguish between missing help pages and missing help context (context can be fixed by user)

Signed-off-by: Daniel Maleike <code@maleike.de>