### PR TITLE
Fix poco path encoding for current locale

### DIFF
--- a/Modules/SceneSerialization/src/mitkSceneIO.cpp
+++ b/Modules/SceneSerialization/src/mitkSceneIO.cpp
@@ -154,6 +154,7 @@ mitk::DataStorage::Pointer mitk::SceneIO::LoadScene(const std::string &filename,
 
   // test if index.xml exists
   // parse index.xml with TinyXML
+  m_WorkingDirectory = Poco::Path::transcode(m_WorkingDirectory);
   TiXmlDocument document(m_WorkingDirectory + mitk::IOUtil::GetDirectorySeparator() + "index.xml");
   if (!document.LoadFile())
   {


### PR DESCRIPTION
without transcode working directory will be locale-dependent, will fault on non-english path