### PR TITLE
Call Modified() on ColorProperty modifications

### DIFF
--- a/Modules/Core/src/DataManagement/mitkLookupTableProperty.cpp
+++ b/Modules/Core/src/DataManagement/mitkLookupTableProperty.cpp
@@ -67,6 +67,7 @@ void mitk::LookupTableProperty::SetLookupTable(const mitk::LookupTable::Pointer 
 void mitk::LookupTableProperty::SetValue(const ValueType &value)
 {
   SetLookupTable(value);
+  this->Modified();
 }
 
 itk::LightObject::Pointer mitk::LookupTableProperty::InternalClone() const


### PR DESCRIPTION
Need a Modified() somewhere for callback to work. I'm not sure this is the right place though. I didn't found any in GenericProperty<T> but I found Modified() in some other properties.

Signed-off-by: Nil Goyette nil.goyette@imeka.ca