### PR TITLE
Don't hide helper objects on Show Only Selected Nodes

### DIFF
--- a/Plugins/org.mitk.gui.qt.datamanager/src/QmitkDataManagerView.cpp
+++ b/Plugins/org.mitk.gui.qt.datamanager/src/QmitkDataManagerView.cpp
@@ -1023,7 +1023,12 @@ void QmitkDataManagerView::ShowOnlySelectedNodes( bool )
 
   foreach(mitk::DataNode::Pointer node, allNodes)
   {
-    node->SetVisibility(selectedNodes.contains(node));
+    bool isHelperObject = false;
+    node->GetBoolProperty("helper object", isHelperObject);
+    if (!isHelperObject)
+    {
+      node->SetVisibility(selectedNodes.contains(node));
+    }
   }
   mitk::RenderingManager::GetInstance()->RequestUpdateAll();
 }


### PR DESCRIPTION
We have been using this code since in MITK 2015.05, 2016.03 and now 2016.11 in our in-hoiuse applications without anyone complaining :)

I know this is not a 100% obvious decision to not hide helper objects but it does make more sense than what MITK currently does! Helper objects are not in the DM (by default in the preferences) so a user clicking on "Show Only Selected Node" just losts some nodes, with no fast way to get them back, possibly not knowing about the preference options.

Signed-off-by: Nil Goyette nil.goyette@imeka.ca