### PR TITLE
Find icons in contextMenuAction extension point

### DIFF
--- a/Plugins/org.mitk.gui.qt.datamanager/src/QmitkDataManagerView.cpp
+++ b/Plugins/org.mitk.gui.qt.datamanager/src/QmitkDataManagerView.cpp
@@ -48,6 +48,8 @@ See LICENSE.txt or http://www.mitk.org for details.
 #include "src/internal/QmitkInfoDialog.h"
 #include "src/internal/QmitkDataManagerItemDelegate.h"
 //## Berry
+#include <berryAbstractUICTKPlugin.h>
+#include <berryIContributor.h>
 #include <berryIEditorPart.h>
 #include <berryIWorkbenchPage.h>
 #include <berryIPreferencesService.h>
@@ -288,7 +290,17 @@ void QmitkDataManagerView::CreateQtPartControl(QWidget* parent)
       // check if the user specified an icon attribute
       if ( !cmIcon.isEmpty() )
       {
-        contextMenuAction = new QAction( QIcon(cmIcon), cmLabel, parent);
+        QIcon icon;
+        if (QFile::exists(cmIcon))
+        {
+          icon = QIcon(cmIcon);
+        }
+        else
+        {
+          icon = berry::AbstractUICTKPlugin::ImageDescriptorFromPlugin(
+            (*cmActionsIt)->GetContributor()->GetName(), cmIcon);
+        }
+        contextMenuAction = new QAction(icon, cmLabel, parent);
       }
       else
       {


### PR DESCRIPTION
Retrieving icon by doing QIcon(iconPath) works only when the icon is a
resource of the same plugin, so only icons of the DataManager plugin were
found. This fix enables getting ions from other plugins (requested by
plugin.xml).

Signed-off-by: Nil Goyette <nil.goyette@imeka.ca>