### PR TITLE
Fix crash on Threshold

### DIFF
--- a/Modules/Segmentation/Interactions/mitkBinaryThresholdTool.cpp
+++ b/Modules/Segmentation/Interactions/mitkBinaryThresholdTool.cpp
@@ -130,6 +130,16 @@ void mitk::BinaryThresholdTool::SetThresholdValue(double value)
 {
   if (m_ThresholdFeedbackNode.IsNotNull())
   {
+    /* If value is not in the min/max range, do nothing. In that case, this
+       method will be called again with a proper value right after. The only
+       known case where this happens is with an [0.0, 1.0[ image, where value
+       could be an epsilon greater than the max. */
+    if (value < m_SensibleMinimumThresholdValue
+     || value > m_SensibleMaximumThresholdValue)
+    {
+      return;
+    }
+
     m_CurrentThresholdValue = value;
     // Bug 19250: The range of 0.01 is rather random. It was 0.001 before and probably due to rounding error propagation
     // in VTK code


### PR DESCRIPTION
Image with intensity in range [0.0, 1.0[ crashed the segmentation plugin because the BinaryThresholdImageFilter received a low value greater than the high value. There's a better explnanation in the [bug report](https://phabricator.mitk.org/T22870).

Signed-off-by: Nil Goyette <nil.goyette@imeka.ca>