### PR TITLE
Correction to be able to retrieve ctk locations via berry::Platform

### DIFF
--- a/Plugins/org.blueberry.core.runtime/src/internal/berryInternalPlatform.cpp
+++ b/Plugins/org.blueberry.core.runtime/src/internal/berryInternalPlatform.cpp
@@ -311,6 +311,26 @@ void InternalPlatform::CloseServiceTrackers()
     m_DebugTracker->close();
     m_DebugTracker.reset();
   }
+
+  if (!configurationLocation.isNull()) {
+    configurationLocation->close();
+    configurationLocation.reset();
+  }
+
+  if (!installLocation.isNull()) {
+    installLocation->close();
+    installLocation.reset();
+  }
+
+  if (!instanceLocation.isNull()) {
+    instanceLocation->close();
+    instanceLocation.reset();
+  }
+
+  if (!userLocation.isNull()) {
+    userLocation->close();
+    userLocation.reset();
+  }
 }
 
 void InternalPlatform::InitializeDebugFlags()
@@ -341,13 +361,13 @@ ctkLocation* InternalPlatform::GetConfigurationLocation()
 ctkLocation* InternalPlatform::GetInstallLocation()
 {
   this->AssertInitialized();
-  return configurationLocation->getService();
+  return installLocation->getService();
 }
 
 ctkLocation* InternalPlatform::GetInstanceLocation()
 {
   this->AssertInitialized();
-  return installLocation->getService();
+  return instanceLocation->getService();
 }
 
 QDir InternalPlatform::GetStateLocation(const QSharedPointer<ctkPlugin>& plugin)


### PR DESCRIPTION
Two bugs in berry::InternalPlatform:

1. confusion between service variables installLocation and instanceLocation,
2. locations are not closed correctly that gives a segfault when the application closes.

Important: to have the functionality, there is also a correction in ctk to apply (cf. https://github.com/commontk/CTK/pull/719). The second bug can be seen only after applying the ctk correction, without it InternalPlatform cannot find locations at all (all pointers are null).