### PR TITLE
Fix for determining axes corresponding to given orientations

### DIFF
--- a/Modules/Core/include/mitkBaseGeometry.h
+++ b/Modules/Core/include/mitkBaseGeometry.h
@@ -537,6 +537,16 @@ namespace mitk
 
         const GeometryTransformHolder *GetGeometryTransformHolder() const;
 
+    //##Documentation
+    //## @brief Determines which axes correspond to each orientation.
+    //##
+    //## The result is stored in the output argument that must be an array of three int values.
+    //## The elements of the array will be the axis indices that correspond to the sagittal,
+    //## coronal and axial orientations, in this order.
+    //##
+    //## @param axes Output argument that will store the axis indices for each orientation.
+    void GetAxesByOrientation(int axes[]) const;
+
   protected:
     // ********************************** Constructor **********************************
     BaseGeometry();


### PR DESCRIPTION
In extreme cases when the volume was rotated around one or two world axes
by exactly 45 degrees, the same axis could be mapped to different orientations
and some other axes were not mapped to any orientations. This resulted in a
incorrectly composed transformation matrix, and the application crashed because
of an ITK exception that was thrown because the inverse matrix could not be
calculated.

This commit has a more clever way of mapping axes to each orientation. It ensures
that different axes are mapped to different orientations.

Signed-off-by: Miklos Espak <m.espak@ucl.ac.uk>