### PR TITLE
Fix for determining axes corresponding to given orientations

### DIFF
--- a/Modules/Core/include/mitkBaseGeometry.h
+++ b/Modules/Core/include/mitkBaseGeometry.h
@@ -537,6 +537,17 @@ namespace mitk
 
         const GeometryTransformHolder *GetGeometryTransformHolder() const;
 
+    //##Documentation
+    //## @brief One to one mapping of axes to world orientations.
+    //##
+    //## The result is stored in the output argument that must be an array of three int values.
+    //## The elements of the array will be the axis indices that correspond to the sagittal,
+    //## coronal and axial orientations, in this order. It is guaranteed that each axis will
+    //## be mapped to different orientations.
+    //##
+    //## @param axes Output argument that will store the axis indices for each orientation.
+    void MapAxesToOrientations(int axes[]) const;
+
   protected:
     // ********************************** Constructor **********************************
     BaseGeometry();

--- a/Modules/Core/src/DataManagement/mitkBaseGeometry.cpp
+++ b/Modules/Core/src/DataManagement/mitkBaseGeometry.cpp
@@ -822,6 +822,90 @@ const mitk::GeometryTransformHolder *mitk::BaseGeometry::GetGeometryTransformHol
   return m_GeometryTransform;
 }
 
+void mitk::BaseGeometry::MapAxesToOrientations(int axes[]) const
+{
+  mitk::AffineTransform3D::ConstPointer affineTransform = this->GetIndexToWorldTransform();
+  mitk::AffineTransform3D::MatrixType matrix = affineTransform->GetMatrix();
+  matrix.GetVnlMatrix().normalize_columns();
+  mitk::AffineTransform3D::MatrixType::InternalMatrixType inverseMatrix = matrix.GetInverse();
+
+  bool mapped[3] = {false, false, false};
+
+  /// We need to allow an epsilon difference to ignore rounding.
+  const double eps = 0.0001;
+
+  for (int orientation = 0; orientation < 3; ++orientation)
+  {
+    double absX = std::abs(inverseMatrix[0][orientation]);
+    double absY = std::abs(inverseMatrix[1][orientation]);
+    double absZ = std::abs(inverseMatrix[2][orientation]);
+
+    /// First we check if there is a single maximum value. If there is, we found the axis
+    /// that corresponds to the given orientation. If there is no single maximum value,
+    /// we choose one from the the two or three axes that have the maximum value, but we
+    /// need to make sure that we do not map the same axis to different orientations.
+    /// Equal values are valid if the volume is rotated by exactly 45 degrees around one
+    /// axis. If the volume is rotated by 45 degrees around two axes, you will get single
+    /// maximum values at the same axes for two different orientations. In this case,
+    /// the axis is mapped to one of the orientations, and for the other orientation we
+    /// choose a different axis that has not been mapped yet, even if it is not a maximum.
+
+    if (absX > absY + eps)
+    {
+      if (absX > absZ + eps)
+      {
+        /// x is the greatest
+        int axis = !mapped[0] ? 0 : !mapped[1] ? 1 : 2;
+        axes[orientation] = axis;
+        mapped[axis] = true;
+      }
+      else
+      {
+        /// z is the greatest OR x and z are equal and greater than y
+        int axis = !mapped[2] ? 2 : !mapped[0] ? 0 : 1;
+        axes[orientation] = axis;
+        mapped[axis] = true;
+      }
+    }
+    else if (absY > absX + eps)
+    {
+      if (absY > absZ + eps)
+      {
+        /// y is the greatest
+        int axis = !mapped[1] ? 1 : !mapped[2] ? 2 : 0;
+        axes[orientation] = axis;
+        mapped[axis] = true;
+      }
+      else
+      {
+        /// z is the greatest OR y and z are equal and greater than x
+        int axis = !mapped[2] ? 2 : !mapped[1] ? 1 : 0;
+        axes[orientation] = axis;
+        mapped[axis] = true;
+      }
+    }
+    else
+    {
+      if (absZ > absX + eps)
+      {
+        /// z is the greatest
+        int axis = !mapped[2] ? 2 : !mapped[0] ? 0 : 1;
+        axes[orientation] = axis;
+        mapped[axis] = true;
+      }
+      else
+      {
+        /// x and y are equal and greater than z OR x and y and z are equal
+        int axis = !mapped[0] ? 0 : !mapped[1] ? 1 : 2;
+        axes[orientation] = axis;
+        mapped[axis] = true;
+      }
+    }
+  }
+
+  assert(mapped[0] && mapped[1] && mapped[2]);
+}
+
 bool mitk::Equal(const mitk::BaseGeometry::BoundingBoxType *leftHandSide,
                  const mitk::BaseGeometry::BoundingBoxType *rightHandSide,
                  ScalarType eps,

--- a/Modules/Core/src/DataManagement/mitkPlaneGeometry.cpp
+++ b/Modules/Core/src/DataManagement/mitkPlaneGeometry.cpp
@@ -390,9 +390,6 @@ namespace mitk
 
     ScalarType width, height;
 
-    // Inspired by:
-    // http://www.na-mic.org/Wiki/index.php/Coordinate_System_Conversion_Between_ITK_and_Slicer3
-
     mitk::AffineTransform3D::MatrixType matrix = geometry3D->GetIndexToWorldTransform()->GetMatrix();
 
     matrix.GetVnlMatrix().normalize_columns();
@@ -400,6 +397,8 @@ namespace mitk
 
     /// The index of the sagittal, coronal and axial axes in the reference geometry.
     int axes[3];
+    geometry3D->MapAxesToOrientations(axes);
+
     /// The direction of the sagittal, coronal and axial axes in the reference geometry.
     /// +1 means that the direction is straight, i.e. greater index translates to greater
     /// world coordinate. -1 means that the direction is inverted.
@@ -408,15 +407,10 @@ namespace mitk
     ScalarType spacings[3];
     for (int i = 0; i < 3; ++i)
     {
-      int dominantAxis = itk::Function::Max3(
-          inverseMatrix[0][i],
-          inverseMatrix[1][i],
-          inverseMatrix[2][i]
-      );
-      axes[i] = dominantAxis;
-      directions[i] = itk::Function::Sign(inverseMatrix[dominantAxis][i]);
-      extents[i] = geometry3D->GetExtent(dominantAxis);
-      spacings[i] = geometry3D->GetSpacing()[dominantAxis];
+      int axis = axes[i];
+      directions[i] = itk::Function::Sign(inverseMatrix[axis][i]);
+      extents[i] = geometry3D->GetExtent(axis);
+      spacings[i] = geometry3D->GetSpacing()[axis];
     }
 
     // matrix(column) = inverseTransformMatrix(row) * flippedAxes * spacing
@@ -505,21 +499,11 @@ namespace mitk
       itkExceptionMacro("unknown PlaneOrientation");
     }
 
-    // Inspired by:
-    // http://www.na-mic.org/Wiki/index.php/Coordinate_System_Conversion_Between_ITK_and_Slicer3
+    int axes[3];
+    geometry3D->MapAxesToOrientations(axes);
+    int axis = axes[worldAxis];
 
-    mitk::AffineTransform3D::ConstPointer affineTransform = geometry3D->GetIndexToWorldTransform();
-    mitk::AffineTransform3D::MatrixType matrix = affineTransform->GetMatrix();
-    matrix.GetVnlMatrix().normalize_columns();
-    mitk::AffineTransform3D::MatrixType::InternalMatrixType inverseMatrix = matrix.GetInverse();
-
-    /// The index of the sagittal, coronal and axial axes in the reference geometry.
-    int dominantAxis = itk::Function::Max3(
-        inverseMatrix[0][worldAxis],
-        inverseMatrix[1][worldAxis],
-        inverseMatrix[2][worldAxis]);
-
-    ScalarType zPosition = top ? 0.5 : geometry3D->GetExtent(dominantAxis) - 0.5;
+    ScalarType zPosition = top ? 0.5 : geometry3D->GetExtent(axis) - 0.5;
 
     InitializeStandardPlane(geometry3D, planeorientation, zPosition, frontside, rotated, top);
   }

--- a/Modules/Core/src/DataManagement/mitkSlicedGeometry3D.cpp
+++ b/Modules/Core/src/DataManagement/mitkSlicedGeometry3D.cpp
@@ -233,32 +233,24 @@ void mitk::SlicedGeometry3D::InitializePlanes(const mitk::BaseGeometry *geometry
       planeorientation == PlaneGeometry::Sagittal ? 0 :
       planeorientation == PlaneGeometry::Frontal  ? 1 : 2;
 
-  // Inspired by:
-  // http://www.na-mic.org/Wiki/index.php/Coordinate_System_Conversion_Between_ITK_and_Slicer3
+  int axes[3];
+  geometry3D->MapAxesToOrientations(axes);
+  int axis = axes[worldAxis];
 
+  ScalarType viewSpacing = geometry3D->GetSpacing()[axis];
+  unsigned int slices = static_cast<unsigned int>(geometry3D->GetExtent(axis));
+
+#ifndef NDEBUG
   mitk::AffineTransform3D::MatrixType matrix = geometry3D->GetIndexToWorldTransform()->GetMatrix();
   matrix.GetVnlMatrix().normalize_columns();
   mitk::AffineTransform3D::MatrixType::InternalMatrixType inverseMatrix = matrix.GetInverse();
 
-  int dominantAxis = itk::Function::Max3(
-      inverseMatrix[0][worldAxis],
-      inverseMatrix[1][worldAxis],
-      inverseMatrix[2][worldAxis]);
-
-  ScalarType viewSpacing = geometry3D->GetSpacing()[dominantAxis];
-
-  /// Although the double value returned by GetExtent() holds a round number,
-  /// you need to add 0.5 to safely convert it to unsigned it. I have seen a
-  /// case when the result was less by one without this.
-  unsigned int slices = static_cast<unsigned int>(geometry3D->GetExtent(dominantAxis) + 0.5);
-
-#ifndef NDEBUG
-  int upDirection = itk::Function::Sign(inverseMatrix[dominantAxis][worldAxis]);
+  int upDirection = itk::Function::Sign(inverseMatrix[axis][worldAxis]);
 
   /// The normal vector of an imaginary plane that points from the world origin (bottom left back
   /// corner or the world, with the lowest physical coordinates) towards the inside of the volume,
   /// along the renderer axis. Length is the slice thickness.
-  Vector3D worldPlaneNormal = inverseMatrix.get_row(dominantAxis) * (upDirection * viewSpacing);
+  Vector3D worldPlaneNormal = inverseMatrix.get_row(axis) * (upDirection * viewSpacing);
 
   /// The normal of the standard plane geometry just created.
   Vector3D standardPlaneNormal = planeGeometry->GetNormal();


### PR DESCRIPTION
In extreme cases when the volume was rotated around one or two world axes
by exactly 45 degrees, the same axis could be mapped to different orientations
and some other axes were not mapped to any orientations. This resulted in a
incorrectly composed transformation matrix, and the application crashed because
of an ITK exception that was thrown because the inverse matrix could not be
calculated.

This commit changes the way of mapping axes to each orientation. It ensures
that always different axes are mapped to different orientations.

Signed-off-by: Miklos Espak <m.espak@ucl.ac.uk>