### PR TITLE
T23055 fixes the itkSetMacro for std::vector parameter

### DIFF
--- a/Modules/DiffusionImaging/FiberTracking/Algorithms/itkStreamlineTrackingFilter.h
+++ b/Modules/DiffusionImaging/FiberTracking/Algorithms/itkStreamlineTrackingFilter.h
@@ -109,7 +109,12 @@ public:
   itkSetMacro( Random, bool )                         ///< If true, seedpoints are shuffled randomly before tracking
   itkSetMacro( Verbose, bool )                        ///< If true, output tracking progress (might be slower)
   itkSetMacro( UseOutputProbabilityMap, bool)         ///< If true, no tractogram but a probability map is created as output.
-  itkSetMacro( SeedPoints, std::vector< itk::Point<float> >)	///< Use manually defined points in physical space as seed points instead of seed image
+  
+  void SetSeedPoints(std::vector< itk::Point<float> > seedPoints)	///< Use manually defined points in physical space as seed points instead of seed image
+  {
+    m_SeedPoints = seedPoints;
+    this->Modified();
+  }
 
   void SetTrackingHandler( mitk::TrackingDataHandler* h )   ///<
   {


### PR DESCRIPTION
When compiling in Debug in Visual Studio 2015 the compilation fails in line 112 of itkStreamlineTrackingFilter.h. This is the following line:

itkSetMacro( SeedPoints, std::vector< itk::Point<float> >)

In Debug itkSetMacro tries to print a message using itkDebugMacro. It streams the std::vector to a std::ostringstream. In this context there is no overloaded << operator for std::ostream, so it does not compile. I think the best solution is to write a setter for that vector manually, not using the itk macro.

Signed-off-by: Federico E. Milano <fmilano@gmail.com>