### PR TITLE
Disabled Warning C4172 to avoid error when compiling boost named_func…

### DIFF
--- a/Modules/DiffusionImaging/Connectomics/Algorithms/mitkConnectomicsBetweennessHistogram.h
+++ b/Modules/DiffusionImaging/Connectomics/Algorithms/mitkConnectomicsBetweennessHistogram.h
@@ -21,7 +21,17 @@ See LICENSE.txt or http://www.mitk.org for details.
 
 #include<mitkConnectomicsHistogramBase.h>
 
+
+#ifdef _MSC_VER
+# pragma warning(push)
+# pragma warning(disable: 4172)
+#endif
+
 #include <boost/graph/betweenness_centrality.hpp>
+
+#ifdef _MSC_VER
+# pragma warning(pop)
+#endif
 
 namespace mitk {
 

--- a/Modules/DiffusionImaging/Connectomics/Algorithms/mitkConnectomicsShortestPathHistogram.cpp
+++ b/Modules/DiffusionImaging/Connectomics/Algorithms/mitkConnectomicsShortestPathHistogram.cpp
@@ -17,7 +17,16 @@ See LICENSE.txt or http://www.mitk.org for details.
 
 #include<mitkConnectomicsShortestPathHistogram.h>
 
+#ifdef _MSC_VER
+# pragma warning(push)
+# pragma warning(disable: 4172)
+#endif
+
 #include <boost/graph/dijkstra_shortest_paths.hpp>
+
+#ifdef _MSC_VER
+# pragma warning(pop)
+#endif
 
 #include "mitkConnectomicsConstantsManager.h"
 

--- a/Modules/DiffusionImaging/Connectomics/Algorithms/mitkConnectomicsStatisticsCalculator.cpp
+++ b/Modules/DiffusionImaging/Connectomics/Algorithms/mitkConnectomicsStatisticsCalculator.cpp
@@ -19,9 +19,19 @@ See LICENSE.txt or http://www.mitk.org for details.
 
 #include <numeric>
 
-#include <boost/graph/connected_components.hpp>
 #include <boost/graph/clustering_coefficient.hpp>
+
+#ifdef _MSC_VER
+# pragma warning(push)
+# pragma warning(disable: 4172)
+#endif
+#include <boost/graph/connected_components.hpp>
 #include <boost/graph/betweenness_centrality.hpp>
+
+#ifdef _MSC_VER
+# pragma warning(pop)
+#endif
+
 #include <boost/graph/visitors.hpp>
 
 #include "vnl/algo/vnl_symmetric_eigensystem.h"

--- a/Modules/DiffusionImaging/Connectomics/IODataStructures/mitkConnectomicsNetwork.cpp
+++ b/Modules/DiffusionImaging/Connectomics/IODataStructures/mitkConnectomicsNetwork.cpp
@@ -17,8 +17,19 @@ See LICENSE.txt or http://www.mitk.org for details.
 
 #include "mitkConnectomicsNetwork.h"
 #include <mitkConnectomicsStatisticsCalculator.h>
+
 #include <boost/graph/clustering_coefficient.hpp>
+
+#ifdef _MSC_VER
+# pragma warning(push)
+# pragma warning(disable: 4172)
+#endif
+
 #include <boost/graph/betweenness_centrality.hpp>
+
+#ifdef _MSC_VER
+# pragma warning(pop)
+#endif
 
 /* Constructor and Destructor */
 mitk::ConnectomicsNetwork::ConnectomicsNetwork()

--- a/Modules/DiffusionImaging/Connectomics/IODataStructures/mitkConnectomicsNetwork.h
+++ b/Modules/DiffusionImaging/Connectomics/IODataStructures/mitkConnectomicsNetwork.h
@@ -29,10 +29,6 @@ See LICENSE.txt or http://www.mitk.org for details.
 
 namespace mitk {
 
-#ifdef _MSC_VER
-# pragma warning(disable: 4172)
-#endif
-
   /**
   * \brief Connectomics Network Class
   *

--- a/Modules/DiffusionImaging/Connectomics/IODataStructures/mitkConnectomicsNetwork.h
+++ b/Modules/DiffusionImaging/Connectomics/IODataStructures/mitkConnectomicsNetwork.h
@@ -29,6 +29,10 @@ See LICENSE.txt or http://www.mitk.org for details.
 
 namespace mitk {
 
+#ifdef _MSC_VER
+# pragma warning(disable: 4172)
+#endif
+
   /**
   * \brief Connectomics Network Class
   *


### PR DESCRIPTION
Disabled Warning C4172 to avoid error when compiling boost named_function_params.hpp.

Signed-off-by: Federico E. Milano <fmilano@gmail.com>