### PR TITLE
Added support for preserving tool DataNode color when deserializing a tool storage

### DIFF
--- a/Modules/IGT/IO/mitkNavigationToolReader.cpp
+++ b/Modules/IGT/IO/mitkNavigationToolReader.cpp
@@ -80,13 +80,18 @@ mitk::NavigationTool::Pointer mitk::NavigationToolReader::ConvertDataNodeToNavig
 {
   mitk::NavigationTool::Pointer returnValue = mitk::NavigationTool::New();
 
-  //DateTreeNode with Name and Surface
+  //DateTreeNode with Name, Surface and Color.
   mitk::DataNode::Pointer newNode = mitk::DataNode::New();
   newNode->SetName(node->GetName());
   newNode->SetData(node->GetData());
   bool visible = true;
   node->GetVisibility(visible, NULL);
   newNode->SetVisibility(visible);
+
+  float rgb[3];
+  node->GetColor(rgb);
+  newNode->SetColor(rgb);
+
   returnValue->SetDataNode(newNode);
 
   //Identifier


### PR DESCRIPTION
When deserializing a tool storage, the color in the original serialized DataNode is not preserved when deserializing it.

Signed-off-by: Federico E. Milano <fmilano@gmail.com>