### PR TITLE
Require at least one slice when initializing sliced geometry on objec…

### DIFF
--- a/Modules/Core/src/DataManagement/mitkSlicedGeometry3D.cpp
+++ b/Modules/Core/src/DataManagement/mitkSlicedGeometry3D.cpp
@@ -251,6 +251,10 @@ void mitk::SlicedGeometry3D::InitializePlanes(const mitk::BaseGeometry *geometry
   /// you need to add 0.5 to safely convert it to unsigned it. I have seen a
   /// case when the result was less by one without this.
   unsigned int slices = static_cast<unsigned int>(geometry3D->GetExtent(dominantAxis) + 0.5);
+  if ( slices == 0 && geometry3D->GetExtent(dominantAxis) > 0) {
+      // require at least one slice if there is _some_ extent
+      slices = 1;
+  }
 
 #ifndef NDEBUG
   int upDirection = itk::Function::Sign(inverseMatrix[dominantAxis][worldAxis]);


### PR DESCRIPTION
…ts with non-zero extents

Code expects in multiple places that proper SliceGeometry3Ds
(at least evenly-spaced ones) have plane geometries, i.e. at least
one slice.
This change remedies violated assertions when loading very small
triangle meshes (e.g. extent 0.3 in one dimension).

Signed-off-by: Daniel Maleike <code@maleike.de>