### PR TITLE
HDF5 library: superbuild fails in Install phase of RelWithDebInfo

### DIFF
--- a/CMakeExternals/HDF5.cmake
+++ b/CMakeExternals/HDF5.cmake
@@ -29,6 +29,7 @@ if(MITK_USE_HDF5)
     ExternalProject_Add(${proj}
        URL ${MITK_THIRDPARTY_DOWNLOAD_PREFIX_URL}/hdf5-1.8.17.tar.gz
        URL_MD5 7d572f8f3b798a628b8245af0391a0ca
+       PATCH_COMMAND ${PATCH_COMMAND} -N -p1 -i ${CMAKE_CURRENT_LIST_DIR}/HDF5.patch
        CMAKE_GENERATOR ${gen}
        CMAKE_ARGS
          ${ep_common_args}

--- a/CMakeExternals/HDF5.patch
+++ b/CMakeExternals/HDF5.patch
@@ -1,0 +1,11 @@
+--- a/config/cmake_ext_mod/HDFMacros.cmake
++++ b/config/cmake_ext_mod/HDFMacros.cmake
+@@ -46,7 +46,7 @@
+     get_target_property (target_name ${libtarget} OUTPUT_NAME_RELWITHDEBINFO)
+     install (
+       FILES
+-          ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/${CMAKE_BUILD_TYPE}/${CMAKE_IMPORT_LIBRARY_PREFIX}${target_name}.pdb
++          ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/RelWithDebInfo/${CMAKE_IMPORT_LIBRARY_PREFIX}${target_name}.pdb
+       DESTINATION
+           ${targetdestination}
+       CONFIGURATIONS RelWithDebInfo


### PR DESCRIPTION
… solved in newer versions of the HDF5 library.

Signed-off-by: Federico Milano <fmilano@gmail.com>