### PR TITLE
T24563: Builds Boost in release when RelWithDebInfo is required.

### DIFF
--- a/CMakeExternals/Boost.cmake
+++ b/CMakeExternals/Boost.cmake
@@ -102,7 +102,7 @@ if(NOT DEFINED BOOST_ROOT AND NOT MITK_USE_SYSTEM_Boost)
     endif()
   endif()
 
-  set(_boost_variant "$<$<CONFIG:Debug>:debug>$<$<CONFIG:Release>:release>")
+  set(_boost_variant "$<$<CONFIG:Debug>:debug>$<$<CONFIG:Release>:release>$<$<CONFIG:RelWithDebInfo>:release>$<$<CONFIG:MinRelSize>:release>")
   set(_boost_link shared)
   if(NOT BUILD_SHARED_LIBS)
     set(_boost_link static)


### PR DESCRIPTION
Signed-off-by: Federico Milano <fmilano@gmail.com>