### PR TITLE
Serializes and deserializes the complete DataNode associated with a NavigationTool.

### DIFF
--- a/Modules/IGT/IO/mitkNavigationToolReader.cpp
+++ b/Modules/IGT/IO/mitkNavigationToolReader.cpp
@@ -81,23 +81,21 @@ mitk::NavigationTool::Pointer mitk::NavigationToolReader::ConvertDataNodeToNavig
   mitk::NavigationTool::Pointer returnValue = mitk::NavigationTool::New();
 
   //DateTreeNode with Name and Surface
-  mitk::DataNode::Pointer newNode = mitk::DataNode::New();
-  newNode->SetName(node->GetName());
-  newNode->SetData(node->GetData());
-  bool visible = true;
-  node->GetVisibility(visible, nullptr);
-  newNode->SetVisibility(visible);
-  returnValue->SetDataNode(newNode);
+  returnValue->SetDataNode(node);
 
   //Identifier
   std::string identifier;
   node->GetStringProperty("identifier", identifier);
   returnValue->SetIdentifier(identifier);
 
+  node->RemoveProperty("identifier");
+
   //Serial Number
   std::string serial;
   node->GetStringProperty("serial number", serial);
   returnValue->SetSerialNumber(serial);
+
+  node->RemoveProperty("serial number");
 
   //Tracking Device
   mitk::TrackingDeviceType device_type;
@@ -140,12 +138,16 @@ mitk::NavigationTool::Pointer mitk::NavigationToolReader::ConvertDataNodeToNavig
     }
   }
 
+  node->RemoveProperty("tracking device type");
+
   returnValue->SetTrackingDeviceType(static_cast<mitk::TrackingDeviceType>(device_type));
 
   //Tool Type
   int type;
   node->GetIntProperty("tracking tool type", type);
   returnValue->SetType(static_cast<mitk::NavigationTool::NavigationToolType>(type));
+
+  node->RemoveProperty("tracking tool type");
 
   //Calibration File Name
   std::string calibration_filename;
@@ -160,6 +162,8 @@ mitk::NavigationTool::Pointer mitk::NavigationToolReader::ConvertDataNodeToNavig
     returnValue->SetCalibrationFile(calibration_filename_with_path);
   }
 
+  node->RemoveProperty("toolfileName");
+
   //Tool Landmarks
   mitk::PointSet::Pointer ToolRegLandmarks = mitk::PointSet::New();
   mitk::PointSet::Pointer ToolCalLandmarks = mitk::PointSet::New();
@@ -171,6 +175,9 @@ mitk::NavigationTool::Pointer mitk::NavigationToolReader::ConvertDataNodeToNavig
   ToolCalLandmarks = ConvertStringToPointSet(CalLandmarksString);
   returnValue->SetToolLandmarks(ToolRegLandmarks);
   returnValue->SetToolControlPoints(ToolCalLandmarks);
+
+  node->RemoveProperty("ToolRegistrationLandmarks");
+  node->RemoveProperty("ToolCalibrationLandmarks");
 
   //Tool Tip
   std::string toolTipPositionString;
@@ -188,10 +195,13 @@ mitk::NavigationTool::Pointer mitk::NavigationToolReader::ConvertDataNodeToNavig
     MITK_WARN << "Tooltip definition incomplete: position and orientation have to be set! Skipping tooltip definition.";
   }
 
+  node->RemoveProperty("ToolTipPosition");
+  node->RemoveProperty("ToolAxisOrientation");
+
   //Tool Axis
   std::string ToolAxisString;
   node->GetStringProperty("ToolAxis", ToolAxisString);
-  //returnValue->SetToolAxis(ConvertStringToPoint(ToolAxisString));
+  returnValue->SetToolAxis(ConvertStringToPoint(ToolAxisString));
 
   return returnValue;
 }

--- a/Modules/IGT/IO/mitkNavigationToolWriter.cpp
+++ b/Modules/IGT/IO/mitkNavigationToolWriter.cpp
@@ -101,10 +101,14 @@ bool mitk::NavigationToolWriter::DoWrite(std::string FileName,mitk::NavigationTo
 
 mitk::DataNode::Pointer mitk::NavigationToolWriter::ConvertToDataNode(mitk::NavigationTool::Pointer Tool)
   {
-  mitk::DataNode::Pointer thisTool = mitk::DataNode::New();
+    mitk::DataNode::Pointer thisTool = Tool->GetDataNode();
   //Name
-    if (Tool->GetDataNode().IsNull()) thisTool->SetName("none");
-    else thisTool->SetName(Tool->GetDataNode()->GetName().c_str());
+    if (Tool->GetDataNode().IsNull())
+    {
+      thisTool = mitk::DataNode::New();
+      thisTool->SetName("none");
+    }
+    
   //Identifier
     thisTool->AddProperty("identifier",mitk::StringProperty::New(Tool->GetIdentifier().c_str()));
   //Serial Number
@@ -115,16 +119,6 @@ mitk::DataNode::Pointer mitk::NavigationToolWriter::ConvertToDataNode(mitk::Navi
     thisTool->AddProperty("tracking tool type",mitk::IntProperty::New(Tool->GetType()));
   //Calibration File Name
     thisTool->AddProperty("toolfileName",mitk::StringProperty::New(GetFileWithoutPath(Tool->GetCalibrationFile())));
-  //Surface
-    if (Tool->GetDataNode().IsNotNull()) if (Tool->GetDataNode()->GetData() != nullptr)
-    {
-      thisTool->SetData(Tool->GetDataNode()->GetData());
-  //Visibility
-      bool visible = true;
-      Tool->GetDataNode()->GetVisibility(visible, nullptr);
-      thisTool->SetVisibility(visible);
-    }
-
   //Tool Landmarks
     thisTool->AddProperty("ToolRegistrationLandmarks",mitk::StringProperty::New(ConvertPointSetToString(Tool->GetToolLandmarks())));
     thisTool->AddProperty("ToolCalibrationLandmarks",mitk::StringProperty::New(ConvertPointSetToString(Tool->GetToolControlPoints())));
@@ -136,11 +130,11 @@ mitk::DataNode::Pointer mitk::NavigationToolWriter::ConvertToDataNode(mitk::Navi
       thisTool->AddProperty("ToolAxisOrientation",mitk::StringProperty::New(ConvertQuaternionToString(Tool->GetToolAxisOrientation())));
     }
 
-    //Tool Axis
+  //Tool Axis
     thisTool->AddProperty("ToolAxis", mitk::StringProperty::New(ConvertPointToString(Tool->GetToolAxis())));
 
-  ////Material is not needed, to avoid errors in scene serialization we have to do this:
-    thisTool->ReplaceProperty("material",nullptr);
+  //Material is not needed, to avoid errors in scene serialization we have to do this:
+    thisTool->RemoveProperty("material");
 
 
   return thisTool;


### PR DESCRIPTION
Serializes all the properties of the associated DataNode and reads all the properties in a tool serialized file.

Signed-off-by: Federico Milano <fmilano@gmail.com>