### PR TITLE
Replaced GetLastError Win32 API calls by ERROR_VALUE in mitkSerialCommunication

### DIFF
--- a/Modules/IGT/Common/mitkSerialCommunication.cpp
+++ b/Modules/IGT/Common/mitkSerialCommunication.cpp
@@ -239,7 +239,7 @@ int mitk::SerialCommunication::Send(const std::string& input, bool block)
   if (WriteFile(m_ComPortHandle, input.data(), static_cast<DWORD>(input.size()), &bytesWritten, nullptr) == TRUE)
     return OK;
   else
-    return GetLastError();
+    return ERROR_VALUE;
 
 #else // Posix
   if (m_FileDescriptor == INVALID_HANDLE_VALUE)
@@ -310,7 +310,7 @@ int mitk::SerialCommunication::ApplyConfigurationWin()
     controlSettings.fRtsControl = RTS_CONTROL_DISABLE;
   }
   if (SetCommState(m_ComPortHandle, &controlSettings) == FALSE)    // Configure com port
-    return GetLastError();
+    return ERROR_VALUE;
 
   COMMTIMEOUTS timeouts;
 
@@ -320,7 +320,7 @@ int mitk::SerialCommunication::ApplyConfigurationWin()
   timeouts.WriteTotalTimeoutMultiplier = 0;
   timeouts.WriteTotalTimeoutConstant = m_SendTimeout;
   if (SetCommTimeouts(m_ComPortHandle, &timeouts) == FALSE)  // set timeout values
-    return GetLastError();
+    return ERROR_VALUE;
 
   PurgeComm(m_ComPortHandle, PURGE_TXCLEAR | PURGE_RXCLEAR);  // clear read and write buffers
   return OK;


### PR DESCRIPTION
Replaced GetLastError Win32 API calls by ERROR_VALUE, to avoid inconsistent return values, since OK is defined as 1 and ERROR_VALUE as 0 in mitkSerialCommunication.

Signed-off-by: Federico Milano <fmilano@gmail.com>