### PR TITLE
Add a try/catch block in ThreadStartTracking to manage exceptions

### DIFF
--- a/Modules/IGT/TrackingDevices/mitkNDITrackingDevice.cpp
+++ b/Modules/IGT/TrackingDevices/mitkNDITrackingDevice.cpp
@@ -701,19 +701,33 @@ ITK_THREAD_RETURN_TYPE mitk::NDITrackingDevice::ThreadStartTracking(void* pInfoS
   NDITrackingDevice *trackingDevice = (NDITrackingDevice*)pInfo->UserData;
   if (trackingDevice != nullptr)
   {
-    if (trackingDevice->GetOperationMode() == ToolTracking6D)
-      trackingDevice->TrackTools();             // call TrackTools() from the original object
-    else if (trackingDevice->GetOperationMode() == MarkerTracking3D)
-      trackingDevice->TrackMarkerPositions();   // call TrackMarkerPositions() from the original object
-    else if (trackingDevice->GetOperationMode() == ToolTracking5D)
-      trackingDevice->TrackMarkerPositions(); // call TrackMarkerPositions() from the original object
-    else if (trackingDevice->GetOperationMode() == HybridTracking)
+    try
     {
-      trackingDevice->TrackToolsAndMarkers();
+      if (trackingDevice->GetOperationMode() == ToolTracking6D)
+        trackingDevice->TrackTools();             // call TrackTools() from the original object
+      else if (trackingDevice->GetOperationMode() == MarkerTracking3D)
+        trackingDevice->TrackMarkerPositions();   // call TrackMarkerPositions() from the original object
+      else if (trackingDevice->GetOperationMode() == ToolTracking5D)
+        trackingDevice->TrackMarkerPositions(); // call TrackMarkerPositions() from the original object
+      else if (trackingDevice->GetOperationMode() == HybridTracking)
+      {
+        trackingDevice->TrackToolsAndMarkers();
+      }
+    }
+    catch (...)
+    {
+      trackingDevice->m_ExceptionPtr = std::current_exception();
     }
   }
   trackingDevice->m_ThreadID = 0;  // erase thread id, now that this thread will end.
+
+
   return ITK_THREAD_RETURN_VALUE;
+}
+
+std::exception_ptr mitk::NDITrackingDevice::GetTrackingException()
+{
+  return m_ExceptionPtr;
 }
 
 bool mitk::NDITrackingDevice::StartTracking()

--- a/Modules/IGT/TrackingDevices/mitkNDITrackingDevice.h
+++ b/Modules/IGT/TrackingDevices/mitkNDITrackingDevice.h
@@ -29,6 +29,7 @@ See LICENSE.txt or http://www.mitk.org for details.
 #include "mitkNDIPassiveTool.h"
 #include "mitkSerialCommunication.h"
 
+#include <stdexcept>
 
 namespace mitk
 {
@@ -303,6 +304,12 @@ public:
     */
     static ITK_THREAD_RETURN_TYPE ThreadStartTracking(void* data);
 
+    /**
+    * \brief returns a non null exception pointer if an exception was thrown in the tracking
+    * thread main loop.
+    */
+    std::exception_ptr GetTrackingException();
+
   protected:
     NDITrackingDevice();          ///< Constructor
     ~NDITrackingDevice() override; ///< Destructor
@@ -329,6 +336,7 @@ public:
     OperationMode m_OperationMode;  ///< tracking mode (6D tool tracking, 3D marker tracking,...)
     itk::FastMutexLock::Pointer m_MarkerPointsMutex;  ///< mutex for marker point data container
     MarkerPointContainerType m_MarkerPoints;          ///< container for markers (3D point tracking mode)
+    std::exception_ptr       m_ExceptionPtr;
   };
 } // namespace mitk
 #endif /* MITKNDITRACKINGDEVICE_H_HEADER_INCLUDED_C1C2FCD2 */


### PR DESCRIPTION
Added a try/catch block in ThreadStartTracking and a member std::exception_ptr in mitkNDITrackingDevice so the main thread can access to the exception thrown in the spawned thread context. If there was no exception thrown the std::exception_ptr is a nullptr.

Signed-off-by: Federico Milano <fmilano@gmail.com>