### PR TITLE
Fix gizmo display and moving

### DIFF
--- a/Modules/Gizmo/src/mitkGizmoInteractor.cpp
+++ b/Modules/Gizmo/src/mitkGizmoInteractor.cpp
@@ -216,13 +216,9 @@ void mitk::GizmoInteractor::MoveAlongAxis(StateMachineAction *, InteractionEvent
     return;
   }
 
-  Vector2D axisVector2D = m_InitialClickPosition2D - m_InitialGizmoCenter2D;
-  axisVector2D.Normalize();
-
-  Vector2D movement2D = positionEvent->GetPointerPositionOnScreen() - m_InitialClickPosition2D;
-  double relativeMovement = movement2D * axisVector2D; // projection
-
-  Vector3D movement3D = relativeMovement * m_AxisOfMovement;
+  Vector3D mouseMovement3D = positionEvent->GetPositionInWorld() - m_InitialClickPosition3D;
+  double projectedMouseMovement3D = mouseMovement3D * m_AxisOfMovement;
+  Vector3D movement3D = projectedMouseMovement3D * m_AxisOfMovement;
 
   ApplyTranslationToManipulatedObject(movement3D);
   RenderingManager::GetInstance()->ForceImmediateUpdateAll();

--- a/Modules/Gizmo/src/mitkGizmoMapper2D.cpp
+++ b/Modules/Gizmo/src/mitkGizmoMapper2D.cpp
@@ -20,6 +20,7 @@ See LICENSE.txt or http://www.mitk.org for details.
 
 // MITK includes
 #include <mitkBaseRenderer.h>
+#include <mitkCameraController.h>
 #include <mitkLookupTableProperty.h>
 #include <mitkVtkInterpolationProperty.h>
 #include <mitkVtkRepresentationProperty.h>
@@ -177,6 +178,7 @@ void mitk::GizmoMapper2D::GenerateDataForRenderer(mitk::BaseRenderer *renderer)
 
   // check if something important has changed and we need to re-render
   if ((ls->m_LastUpdateTime >= node->GetMTime()) && (ls->m_LastUpdateTime >= gizmo->GetPipelineMTime()) &&
+      (ls->m_LastUpdateTime >= renderer->GetCameraController()->GetMTime()) &&
       (ls->m_LastUpdateTime >= renderer->GetCurrentWorldPlaneGeometryUpdateTime()) &&
       (ls->m_LastUpdateTime >= renderer->GetCurrentWorldPlaneGeometry()->GetMTime()) &&
       (ls->m_LastUpdateTime >= node->GetPropertyList()->GetMTime()) &&
@@ -215,8 +217,8 @@ void mitk::GizmoMapper2D::GenerateDataForRenderer(mitk::BaseRenderer *renderer)
 
   auto appender = vtkSmartPointer<vtkAppendPolyData>::New();
 
-  double diagonal = std::min(renderer->GetSizeX(), renderer->GetSizeY());
-  double arrowLength = 0.1 * diagonal; // fixed in relation to window size
+  double diagonal = std::min(renderer->GetSizeX(), renderer->GetSizeY()) * renderer->GetScaleFactorMMPerDisplayUnit();
+  double arrowLength = 0.3 * diagonal; // fixed in relation to window size
   auto disk = Create2DDisk(viewRight, viewUp, gizmoCenterView - cameraDirection, 0.1 * arrowLength);
   AssignScalarValueTo(disk, Gizmo::MoveFreely);
   appender->AddInputData(disk);


### PR DESCRIPTION
When moving an object with direct manipulation (gizmo) along a single axis sometimes the controls reverse and the object moves up when dragging down, left when dragging right, etc.
Able to reproduce this issue after turning the object upside down with the rotation provided by direct manipulation.

In addition, 2D display does not scale well depending on the current zoom factor.

Both behaviors were fixed in the two commits provided. Displacement calculation was wrong, 2D rendering did not consider zoom factor.