### PR TITLE
When the workbench window is out of the (default) screen, center it.

### DIFF
--- a/Plugins/org.blueberry.ui.qt/src/internal/berryWorkbenchWindow.cpp
+++ b/Plugins/org.blueberry.ui.qt/src/internal/berryWorkbenchWindow.cpp
@@ -856,9 +856,12 @@ bool WorkbenchWindow::RestoreState(IMemento::Pointer memento,
     //      public void runWithException() {
     if (!shellBounds.intersects(displayBounds))
     {
+      // Center on default screen
       QRect clientArea(Tweaklets::Get(GuiWidgetsTweaklet::KEY)->GetAvailableScreenSize());
-      shellBounds.setX(clientArea.x());
-      shellBounds.setY(clientArea.y());
+      shellBounds.setX(clientArea.width() * 0.05);
+      shellBounds.setY(clientArea.height() * 0.05);
+      shellBounds.setWidth(clientArea.width() * 0.9);
+      shellBounds.setHeight(clientArea.height() * 0.9);
     }
     GetShell()->SetBounds(shellBounds);
     //      }});


### PR DESCRIPTION
Behavior observed on Windows when workbench window is completely on a second screen (not the default screen) and restored the next time that workbench ist started: the window would be displayed with a very small (~20px) width and the titlebar out of reach because above the screen top limit.

Debugging into this brought me to the changed file which applies some logic if the previously stored window position has no overlap with the default screen geometry. This would trigger for the second screen scenario above.

I changed the behavior so that the window will be centered in a
default size of 90% when it does not show on the default screen.
This avoids unusable tiny window sizes.

I would have preferred to restore the original position on the second screen, but this would have required deeper knowledge of the BlueBerry window description and the ability to test any changes on all supported platforms.