### PR TITLE
Add options to skip building the Qt designer plugins

### DIFF
--- a/CMakeExternals/CTK.cmake
+++ b/CMakeExternals/CTK.cmake
@@ -73,6 +73,7 @@ if(MITK_USE_CTK)
         -DQt5_DIR=${Qt5_DIR}
         -DGit_EXECUTABLE:FILEPATH=${GIT_EXECUTABLE}
         -DGIT_EXECUTABLE:FILEPATH=${GIT_EXECUTABLE}
+        -DCTK_BUILD_QTDESIGNER_PLUGINS:BOOL=OFF
         -DCTK_LIB_CommandLineModules/Backend/LocalProcess:BOOL=ON
         -DCTK_LIB_CommandLineModules/Frontend/QtGui:BOOL=ON
         -DCTK_LIB_PluginFramework:BOOL=ON

--- a/CMakeExternals/QwtCMakeLists.txt
+++ b/CMakeExternals/QwtCMakeLists.txt
@@ -183,40 +183,46 @@ set_target_properties(qwt PROPERTIES
 
 # Build the designer plug-in
 
-include_directories(${CMAKE_CURRENT_SOURCE_DIR}/src)
+option(QWT_BUILD_DESIGNER_PLUGIN "Build the Qt Designer plugin" OFF)
+  if (QWT_BUILD_DESIGNER_PLUGIN)
 
-set(_qwt_designer_sources
-  designer/qwt_designer_plotdialog.cpp
-  designer/qwt_designer_plugin.cpp
-)
+  include_directories(${CMAKE_CURRENT_SOURCE_DIR}/src)
 
-set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/plugins/designer)
-set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/plugins/designer)
-set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/plugins/designer)
+  set(_qwt_designer_sources
+    designer/qwt_designer_plotdialog.cpp
+    designer/qwt_designer_plugin.cpp
+  )
 
-find_package(Qt5Designer REQUIRED)
-include_directories(${Qt5Designer_INCLUDE_DIRS})
-qt5_wrap_cpp(_qwt_designer_sources
-  designer/qwt_designer_plugin.h
-  designer/qwt_designer_plotdialog.h
-)
-qt5_add_resources(_qwt_designer_sources designer/qwt_designer_plugin.qrc)
+  set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/plugins/designer)
+  set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/plugins/designer)
+  set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/plugins/designer)
 
-add_library(qwt_designer_plugin SHARED ${_qwt_designer_sources})
-target_link_libraries(qwt_designer_plugin qwt Qt5::Designer)
+  find_package(Qt5Designer REQUIRED)
+  include_directories(${Qt5Designer_INCLUDE_DIRS})
+  qt5_wrap_cpp(_qwt_designer_sources
+    designer/qwt_designer_plugin.h
+    designer/qwt_designer_plotdialog.h
+  )
+  qt5_add_resources(_qwt_designer_sources designer/qwt_designer_plugin.qrc)
 
-set_target_properties(qwt_designer_plugin PROPERTIES
-                      SOVERSION ${${PROJECT_NAME}_VERSION}
-                      COMPILE_DEFINITIONS QWT_DLL)
+  add_library(qwt_designer_plugin SHARED ${_qwt_designer_sources})
+  target_link_libraries(qwt_designer_plugin qwt Qt5::Designer)
+
+  set_target_properties(qwt_designer_plugin PROPERTIES
+                        SOVERSION ${${PROJECT_NAME}_VERSION}
+                        COMPILE_DEFINITIONS QWT_DLL)
+endif()
 
 set(${PROJECT_NAME}_LIBRARIES qwt)
 
 # Install support
 
-install(TARGETS qwt_designer_plugin
-  RUNTIME DESTINATION plugins/designer
-  LIBRARY DESTINATION plugins/designer
-)
+if (QWT_BUILD_DESIGNER_PLUGIN)
+  install(TARGETS qwt_designer_plugin
+    RUNTIME DESTINATION plugins/designer
+    LIBRARY DESTINATION plugins/designer
+  )
+endif()
 
 install(TARGETS ${${PROJECT_NAME}_LIBRARIES} EXPORT ${PROJECT_NAME}_TARGETS
   LIBRARY DESTINATION lib


### PR DESCRIPTION
Not sure if you'd like to integrate this - but there are chances that nobody ever used Qt Designer plugins.

I had issues building MITK inside a specific environment because two Qt Designer plugin classes would produce compiler errors that I was unable to correct. Consequently, I introduced two changes with this patch:

* disable CTK Qt Designer plugins by providing CTK_BUILD_QTDESIGNER_PLUGINS:BOOL=OFF
* add a default-off option named QWT_BUILD_DESIGNER_PLUGIN to CMakeExternals/QwtCMakeLists.txt