### PR TITLE
Forward vtkInformation objects to MITK mappers - enable VTK depth peeling

### DIFF
--- a/CMakeExternals/VTK-8.1.0.patch
+++ b/CMakeExternals/VTK-8.1.0.patch
@@ -1,0 +1,80 @@
+diff --git a/Rendering/Core/vtkAssembly.cxx b/Rendering/Core/vtkAssembly.cxx
+index 79e4d42b65..b17c74e659 100644
+--- a/Rendering/Core/vtkAssembly.cxx
++++ b/Rendering/Core/vtkAssembly.cxx
+@@ -116,6 +116,7 @@ int vtkAssembly::RenderTranslucentPolygonalGeometry(vtkViewport *ren)
+     vtkProp3D* prop3D = static_cast<vtkProp3D *>(path->GetLastNode()->GetViewProp());
+     if ( prop3D->GetVisibility() )
+     {
++      prop3D->SetPropertyKeys(this->GetPropertyKeys());
+       prop3D->SetAllocatedRenderTime(fraction, ren);
+       prop3D->PokeMatrix(path->GetLastNode()->GetMatrix());
+       renderedSomething += prop3D->RenderTranslucentPolygonalGeometry(ren);
+@@ -143,6 +144,7 @@ int vtkAssembly::HasTranslucentPolygonalGeometry()
+     vtkProp3D* prop3D = static_cast<vtkProp3D *>(path->GetLastNode()->GetViewProp());
+     if ( prop3D->GetVisibility() )
+     {
++      prop3D->SetPropertyKeys(this->GetPropertyKeys());
+       result = prop3D->HasTranslucentPolygonalGeometry();
+     }
+   }
+@@ -175,6 +177,7 @@ int vtkAssembly::RenderVolumetricGeometry(vtkViewport *ren)
+     vtkProp3D* prop3D = static_cast<vtkProp3D *>(path->GetLastNode()->GetViewProp());
+     if (prop3D->GetVisibility())
+     {
++      prop3D->SetPropertyKeys(this->GetPropertyKeys());
+       prop3D->SetAllocatedRenderTime(fraction, ren);
+       prop3D->PokeMatrix(path->GetLastNode()->GetMatrix());
+       renderedSomething += prop3D->RenderVolumetricGeometry(ren);
+@@ -210,6 +213,7 @@ int vtkAssembly::RenderOpaqueGeometry(vtkViewport *ren)
+     vtkProp3D* prop3D = static_cast<vtkProp3D *>(path->GetLastNode()->GetViewProp());
+     if (prop3D->GetVisibility())
+     {
++      prop3D->SetPropertyKeys(this->GetPropertyKeys());
+       prop3D->PokeMatrix(path->GetLastNode()->GetMatrix());
+       prop3D->SetAllocatedRenderTime(fraction, ren);
+       renderedSomething += prop3D->RenderOpaqueGeometry(ren);
+diff --git a/Rendering/Core/vtkPropAssembly.cxx b/Rendering/Core/vtkPropAssembly.cxx
+index 5033c3b66e..405b1a75ab 100644
+--- a/Rendering/Core/vtkPropAssembly.cxx
++++ b/Rendering/Core/vtkPropAssembly.cxx
+@@ -97,6 +97,7 @@ int vtkPropAssembly::RenderTranslucentPolygonalGeometry(vtkViewport *ren)
+     prop = path->GetLastNode()->GetViewProp();
+     if ( prop->GetVisibility() )
+     {
++      prop->SetPropertyKeys(this->GetPropertyKeys());
+       prop->SetAllocatedRenderTime(fraction, ren);
+       prop->PokeMatrix(path->GetLastNode()->GetMatrix());
+       renderedSomething += prop->RenderTranslucentPolygonalGeometry(ren);
+@@ -125,6 +126,7 @@ int vtkPropAssembly::HasTranslucentPolygonalGeometry()
+     prop = path->GetLastNode()->GetViewProp();
+     if ( prop->GetVisibility() )
+     {
++      prop->SetPropertyKeys(this->GetPropertyKeys());
+       result=prop->HasTranslucentPolygonalGeometry();
+     }
+   }
+@@ -154,6 +156,7 @@ int vtkPropAssembly::RenderVolumetricGeometry(vtkViewport *ren)
+     prop = path->GetLastNode()->GetViewProp();
+     if ( prop->GetVisibility() )
+     {
++      prop->SetPropertyKeys(this->GetPropertyKeys());
+       prop->SetAllocatedRenderTime(fraction, ren);
+       prop->PokeMatrix(path->GetLastNode()->GetMatrix());
+       renderedSomething += prop->RenderVolumetricGeometry(ren);
+@@ -186,6 +189,7 @@ int vtkPropAssembly::RenderOpaqueGeometry(vtkViewport *ren)
+     prop = path->GetLastNode()->GetViewProp();
+     if ( prop->GetVisibility() )
+     {
++      prop->SetPropertyKeys(this->GetPropertyKeys());
+       prop->SetAllocatedRenderTime(fraction, ren);
+       prop->PokeMatrix(path->GetLastNode()->GetMatrix());
+       renderedSomething += prop->RenderOpaqueGeometry(ren);
+@@ -217,6 +221,7 @@ int vtkPropAssembly::RenderOverlay(vtkViewport *ren)
+     prop = path->GetLastNode()->GetViewProp();
+     if ( prop->GetVisibility() )
+     {
++      prop->SetPropertyKeys(this->GetPropertyKeys());
+       prop->SetAllocatedRenderTime(fraction, ren);
+       prop->PokeMatrix(path->GetLastNode()->GetMatrix());
+       renderedSomething += prop->RenderOverlay(ren);

--- a/CMakeExternals/VTK.cmake
+++ b/CMakeExternals/VTK.cmake
@@ -66,11 +66,15 @@ if(NOT DEFINED VTK_DIR)
       "-DCMAKE_PROJECT_${proj}_INCLUDE:FILEPATH=${CMAKE_ROOT}/Modules/CTestUseLaunchers.cmake"
     )
   endif()
+  
+  set (VTK_PATCH_OPTION
+       PATCH_COMMAND ${PATCH_COMMAND} -p1 -i ${CMAKE_CURRENT_LIST_DIR}/VTK-8.1.0.patch)
 
   ExternalProject_Add(${proj}
     LIST_SEPARATOR ${sep}
     URL ${MITK_THIRDPARTY_DOWNLOAD_PREFIX_URL}/VTK-8.1.0.tar.gz
     URL_MD5 4fa5eadbc8723ba0b8d203f05376d932
+    ${VTK_PATCH_OPTION}
     CMAKE_GENERATOR ${gen}
     CMAKE_ARGS
         ${ep_common_args}

--- a/Modules/Core/include/mitkVtkPropRenderer.h
+++ b/Modules/Core/include/mitkVtkPropRenderer.h
@@ -85,6 +85,9 @@ namespace mitk
       Volumetric
     };
 
+    /** \brief store/propagate vtkInformation during rendering */
+    void SetPropertyKeys(vtkInformation *info);
+
     int Render(RenderType type);
 
     /** \brief This methods contains all method neceassary before a VTK Render() call */
@@ -212,6 +215,9 @@ namespace mitk
     // prepare all mitk::mappers for rendering
     void PrepareMapperQueue();
 
+    /** \brief Propagate vtkInformation object to all VTK-based mappers */
+    void PropagateRenderInfoToMappers();
+
     /** \brief Set parallel projection, remove the interactor and the lights of VTK. */
     bool Initialize2DvtkCamera();
 
@@ -238,6 +244,14 @@ namespace mitk
     vtkRenderer *m_TextRenderer;
     typedef std::map<unsigned int, vtkTextActor *> TextMapType;
     TextMapType m_TextCollection;
+
+   /** \brief Information passed from VTK's rendering to props.
+
+       Used e.g. by vtkDualDepthPeelingPass to pass information.
+       Not passing this to all the MITK generated vktProps will
+       essentially break VTK's depth peeling / transparency.
+    */
+    vtkInformation* m_VtkRenderInfo = nullptr;
   };
 } // namespace mitk
 

--- a/Modules/Core/include/vtkMitkRenderProp.h
+++ b/Modules/Core/include/vtkMitkRenderProp.h
@@ -25,7 +25,7 @@ See LICENSE.txt or http://www.mitk.org for details.
 
 The MITK rendering process is completely integrated into the VTK rendering pipeline.
 The vtkMitkRenderProp is a custom vtkProp derived class, which implements the rendering interface between MITK and VTK.
-It redirects render() calls to the VtkPropRenderer, which is responsible for rendering of the datatreenodes.
+It redirects VTK's various Render..Geometry() calls to mitk::VtkPropRenderer, which is responsible for rendering of mitk::DataNodes.
 
 \sa rendering
 \ingroup rendering
@@ -37,6 +37,14 @@ public:
   vtkTypeMacro(vtkMitkRenderProp, vtkProp);
 
   void SetPropRenderer(mitk::VtkPropRenderer::Pointer propRenderer);
+
+  /**
+   * \brief Store a vtkInformation object
+   *
+   * This method will forward the vtkInformation object
+   * to the vtkProps of all mitk::VtkMapper
+   */
+  void SetPropertyKeys(vtkInformation *keys) override;
 
   int RenderOpaqueGeometry(vtkViewport *viewport) override;
 
@@ -60,7 +68,6 @@ public:
 
   int GetNumberOfPaths() override;
 
-  // BUG (#1551) added method for depth peeling support
   int HasTranslucentPolygonalGeometry() override;
   int RenderTranslucentPolygonalGeometry(vtkViewport *) override;
   int RenderVolumetricGeometry(vtkViewport *) override;

--- a/Modules/Core/src/Rendering/mitkVtkPropRenderer.cpp
+++ b/Modules/Core/src/Rendering/mitkVtkPropRenderer.cpp
@@ -40,6 +40,7 @@ See LICENSE.txt or http://www.mitk.org for details.
 #include <vtkCamera.h>
 #include <vtkCellPicker.h>
 #include <vtkInteractorStyleTrackballCamera.h>
+#include <vtkInformation.h>
 #include <vtkLight.h>
 #include <vtkLightKit.h>
 #include <vtkLinearTransform.h>
@@ -169,7 +170,11 @@ int mitk::VtkPropRenderer::Render(mitk::VtkPropRenderer::RenderType type)
 
   // Update mappers and prepare mapper queue
   if (type == VtkPropRenderer::Opaque)
+  {
     this->PrepareMapperQueue();
+    // Share vtkInformation, there might be new mappers
+    this->PropagateRenderInfoToMappers();
+  }
 
   // go through the generated list and let the sorted mappers paint
   for (auto it = m_MappersMap.cbegin(); it != m_MappersMap.cend(); it++)
@@ -255,6 +260,38 @@ void mitk::VtkPropRenderer::PrepareMapperQueue()
     int nr = (layer << 16) + mapperNo;
     m_MappersMap.insert(std::pair<int, Mapper *>(nr, mapper));
     mapperNo++;
+  }
+}
+
+void mitk::VtkPropRenderer::SetPropertyKeys(vtkInformation *info)
+{
+  if (info == m_VtkRenderInfo)
+  {
+    return;
+  }
+
+  m_VtkRenderInfo = info;
+  PropagateRenderInfoToMappers();
+}
+
+void mitk::VtkPropRenderer::PropagateRenderInfoToMappers()
+{
+  if (m_VtkRenderInfo == nullptr)
+  {
+    return;
+  }
+
+  // propagate information to all mappers' vtkProps
+  for (auto &mapEntry : m_MappersMap)
+  {
+    if (auto vtkMapper = dynamic_cast<mitk::VtkMapper *>(mapEntry.second))
+    {
+      vtkProp *prop = vtkMapper->GetVtkProp(this);
+      if (prop)
+      {
+        prop->SetPropertyKeys(m_VtkRenderInfo);
+      }
+    }
   }
 }
 


### PR DESCRIPTION
VTK has a nice way of handling translucent polydata objects which does not work in MITK: depth peeling [1] [2]. This change makes translucent rendering work again.

To enable depth peeling, one would need to initialize a render window as documented:

```
renderWindow->SetAlphaBitPlanes(1);
renderWindow->SetMultiSamples(0);
renderer->SetUseDepthPeeling(1);
renderer->SetMaximumNumberOfPeels(100);
renderer->SetOcclusionRatio(0.1);
```

Doing so in MITK will result in surfaces with opacity < 1 looking horribly bright. Tracing down, this is because VTK rendering provides a vtkInformation object to all rendered vtkProps. MITK breaks this because its primary vtkProp `vtkMitkRenderProp` does not forward this information object to all the mitk::VtkMapper generated vtkProps.

This patch enables forwarding of information and by doing so allows to use depth peeling - allowing to removes the depth sorting option of mitk::Surface.

Resulting images could look like this one:
![grafik](https://user-images.githubusercontent.com/606329/63497069-5ed20600-c4c3-11e9-9f64-5321e7cd9d50.png)

[1] https://blog.kitware.com/vtk-technical-highlight-dual-depth-peeling/
[2] https://vtk.org/Wiki/VTK/Depth_Peeling