### PR TITLE
Gizmo fix: avoid double emission of Modified() signal

### DIFF
--- a/Modules/Gizmo/src/mitkGizmoInteractor.cpp
+++ b/Modules/Gizmo/src/mitkGizmoInteractor.cpp
@@ -298,8 +298,7 @@ void mitk::GizmoInteractor::ApplyTranslationToManipulatedObject(const Vector3D &
   }
 
   manipulatedGeometry->ExecuteOperation(m_FinalDoOperation.get());
-  m_ManipulatedObjectGeometry->SetIdentity();
-  m_ManipulatedObjectGeometry->Compose(manipulatedGeometry->GetIndexToWorldTransform());
+  m_ManipulatedObjectGeometry->SetIndexToWorldTransform(manipulatedGeometry->GetIndexToWorldTransform());
 }
 
 void mitk::GizmoInteractor::ApplyEqualScalingToManipulatedObject(double scalingFactor)
@@ -314,8 +313,7 @@ void mitk::GizmoInteractor::ApplyEqualScalingToManipulatedObject(double scalingF
   }
 
   manipulatedGeometry->ExecuteOperation(m_FinalDoOperation.get());
-  m_ManipulatedObjectGeometry->SetIdentity();
-  m_ManipulatedObjectGeometry->Compose(manipulatedGeometry->GetIndexToWorldTransform());
+  m_ManipulatedObjectGeometry->SetIndexToWorldTransform(manipulatedGeometry->GetIndexToWorldTransform());
 }
 
 void mitk::GizmoInteractor::ApplyRotationToManipulatedObject(double angle_deg)
@@ -331,8 +329,7 @@ void mitk::GizmoInteractor::ApplyRotationToManipulatedObject(double angle_deg)
   }
 
   manipulatedGeometry->ExecuteOperation(m_FinalDoOperation.get());
-  m_ManipulatedObjectGeometry->SetIdentity();
-  m_ManipulatedObjectGeometry->Compose(manipulatedGeometry->GetIndexToWorldTransform());
+  m_ManipulatedObjectGeometry->SetIndexToWorldTransform(manipulatedGeometry->GetIndexToWorldTransform());
 }
 
 void mitk::GizmoInteractor::FeedUndoStack(StateMachineAction *, InteractionEvent *)

--- a/Modules/Gizmo/src/mitkGizmoInteractor.cpp
+++ b/Modules/Gizmo/src/mitkGizmoInteractor.cpp
@@ -199,6 +199,12 @@ void mitk::GizmoInteractor::DecideInteraction(StateMachineAction *, InteractionE
     case Gizmo::ScaleX:
     case Gizmo::ScaleY:
     case Gizmo::ScaleZ:
+      // Implementation note: Why didn't we implement per-axis scaling yet?
+      // When this was implemented, the mitk::ScaleOperation was able to only describe
+      // uniform scaling around a central point. Since we use operations for all modifications
+      // in order to have undo/redo working, any axis-specific scaling should also
+      // use operations.
+      // Consequence: enhance ScaleOperation when there is need to have scaling per axis.
       decision = InternalEvent::New(interactionEvent->GetSender(), this, "ScaleEqually");
       break;
     default:


### PR DESCRIPTION
See subject line. Implementation behavior is the same, only one unintended Modified() signal is avoided.