### PR TITLE
Avoid collapsing 'Properties' view when editing child-properties (e.g. "material.something")

### DIFF
--- a/Modules/QtWidgets/src/QmitkPropertyItemModel.cpp
+++ b/Modules/QtWidgets/src/QmitkPropertyItemModel.cpp
@@ -387,8 +387,6 @@ bool QmitkPropertyItemModel::setData(const QModelIndex &index, const QVariant &v
 
   auto propertyList = m_PropertyList.Lock();
 
-  propertyList->Modified();
-
   mitk::RenderingManager::GetInstance()->RequestUpdateAll();
 
   return true;


### PR DESCRIPTION
With the current logic, QmitkPropertyItemModelwill rebuild itself whenever the
propertylist changes. This will in consequence collapse a tree view
that displays the model.

That behavior is not nice but can be tolerated when something else in
the application triggers a modification of the propertylist. When the
user modifies a child-item via the 'Properties' view then this
collapsing is very annoying, though.

I couldn't find any negative side-effects of this removal.

Signed-off-by: Daniel Maleike <daniel.maleike@stryker.com>