### PR TITLE
Check filename for invalid characters before saving e.g. "a:b.obj"

### DIFF
--- a/Modules/QtWidgets/src/QmitkIOUtil.cpp
+++ b/Modules/QtWidgets/src/QmitkIOUtil.cpp
@@ -33,45 +33,12 @@ See LICENSE.txt or http://www.mitk.org for details.
 #include <QFileDialog>
 #include <QMessageBox>
 #include <QSet>
+#include <QString>
 
 // ITK
 #include <itksys/SystemTools.hxx>
 
 #include <algorithm>
-
-namespace
-{
-#if defined(_WIN32) || defined(_WIN64)
-    QString s_InvalidFilenameCharacters("<>:\"/\\|?*");
-#else
-    QString s_InvalidFilenameCharacters("/");
-#endif
-
-  // Return 'true' if the specified filename contains characters not accepted by the file system.
-  //
-  // This test is not exhaustive but just excluding the most common problems.
-  bool IsIllegalFilename(const QString &fullFilename)
-  {
-    QFileInfo fi(fullFilename);
-    auto filename = fi.fileName();
-
-    for (auto &ch : s_InvalidFilenameCharacters)
-    {
-      if (filename.contains(ch))
-      {
-        return true;
-      }
-    }
-
-    if (filename.startsWith(' ' || filename.endsWith(' ')))
-    {
-      return true;
-    }
-
-    return false;
-  }
-
-} // unnamed namespace
 
 struct QmitkIOUtil::Impl
 {
@@ -108,7 +75,43 @@ struct QmitkIOUtil::Impl
       }
     }
   };
-};
+
+  //! Filename characters that are not valid - depending on the platform (Windows, Posix)
+  static QString s_InvalidFilenameCharacters;
+
+  //! Return 'true' when:
+  //!  - the specified filename contains characters not accepted by the file system (see s_InvalidFilenameCharacters)
+  //!  - filename starts or ends in space characters
+  //!
+  //! This test is not exhaustive but just excluding the most common problems.
+  static bool IsIllegalFilename(const QString &fullFilename)
+  {
+    QFileInfo fi(fullFilename);
+    auto filename = fi.fileName();
+
+    for (const auto &ch : s_InvalidFilenameCharacters)
+    {
+      if (filename.contains(ch))
+      {
+        return true;
+      }
+    }
+
+    if (filename.startsWith(' ' || filename.endsWith(' ')))
+    {
+      return true;
+    }
+
+    return false;
+  }
+
+}; // Impl
+
+#if defined(_WIN32) || defined(_WIN64)
+  QString QmitkIOUtil::Impl::s_InvalidFilenameCharacters = "<>:\"/\\|?*";
+#else
+  QString QmitkIOUtil::Impl::s_InvalidFilenameCharacters = "/";
+#endif
 
 struct MimeTypeComparison : public std::unary_function<mitk::MimeType, bool>
 {
@@ -279,13 +282,13 @@ QStringList QmitkIOUtil::Save(const std::vector<const mitk::BaseData *> &data,
     // Ask the user for a file name
     QString nextName = QFileDialog::getSaveFileName(parent, dialogTitle, fileName, filterString, &selectedFilter);
 
-    if (IsIllegalFilename(nextName))
+    if (Impl::IsIllegalFilename(nextName))
     {
       QMessageBox::warning(
         parent,
         "Saving not possible",
-        QString("File \"%2\" contains invalid characters.\n\nPlease avoid any of %1")
-          .arg(s_InvalidFilenameCharacters.split("", QString::SkipEmptyParts).join(" "))
+        QString("File \"%2\" contains invalid characters.\n\nPlease avoid any of \"%1\"")
+          .arg(Impl::s_InvalidFilenameCharacters.split("", QString::SkipEmptyParts).join(" "))
           .arg(nextName));
       continue;
     }


### PR DESCRIPTION
Per default the Data Manager's "Save..." option via QmitkIOUtil proposes the DataNode's name as the filename. When the node name is "a:b" or simliar, this might produce files that are empty and named slightly different (in the example "a" instead of "a:b.obj"). The problem is that file systems do not accept all characters (esp. Windows)

Without a in QmitkIOUtil writers might (and some do) create empty files
that are not even named as expected (e.g. "a" instead of "a:b.obj").

The opening of a std::ofstream for such a filename does not seem to set
any fail-bits (all checked for in the affected writer class). So even writers that correctly check for the output stream state won't notice the problem.

The alternative to a check here would be a check in each possible writer class. This seems worse.

Signed-off-by: Daniel Maleike <daniel.maleike@stryker.com>