### PR TITLE
Changing the way that QmitkRenderwindow treats incoming Qt events...

### DIFF
--- a/Modules/QtWidgets/include/QmitkRenderWindow.h
+++ b/Modules/QtWidgets/include/QmitkRenderWindow.h
@@ -89,20 +89,13 @@ public:
   void FullScreenMode(bool state);
 
 protected:
+
+  // catch-all event handler
+  bool event(QEvent *e) override;
   // overloaded move handler
   void moveEvent(QMoveEvent *event) override;
   // overloaded show handler
   void showEvent(QShowEvent *event) override;
-  // overloaded mouse press handler
-  void mousePressEvent(QMouseEvent *event) override;
-  // overloaded mouse double-click handler
-  void mouseDoubleClickEvent(QMouseEvent *event) override;
-  // overloaded mouse move handler
-  void mouseMoveEvent(QMouseEvent *event) override;
-  // overloaded mouse release handler
-  void mouseReleaseEvent(QMouseEvent *event) override;
-  // overloaded key press handler
-  void keyPressEvent(QKeyEvent *event) override;
   // overloaded enter handler
   void enterEvent(QEvent *) override;
   // overloaded leave handler
@@ -118,11 +111,6 @@ protected:
   /// \brief If the dropped type is application/x-mitk-datanodes we process the request by converting to mitk::DataNode
   /// pointers and emitting the NodesDropped signal.
   void dropEvent(QDropEvent *event) override;
-
-#ifndef QT_NO_WHEELEVENT
-  // overload wheel mouse event
-  void wheelEvent(QWheelEvent *) override;
-#endif
 
   void AdjustRenderWindowMenuVisibility(const QPoint &pos);
 

--- a/Modules/QtWidgets/src/QmitkRenderWindow.cpp
+++ b/Modules/QtWidgets/src/QmitkRenderWindow.cpp
@@ -98,6 +98,7 @@ bool QmitkRenderWindow::event(QEvent* e)
     case QEvent::MouseMove:
     {
       auto me = static_cast<QMouseEvent *>(e);
+      this->AdjustRenderWindowMenuVisibility(me->pos());
       mitkEvent = mitk::MouseMoveEvent::New(m_Renderer, GetMousePosition(me), GetButtonState(me), GetModifiers(me));
       break;
     }

--- a/Modules/QtWidgets/src/QmitkRenderWindow.cpp
+++ b/Modules/QtWidgets/src/QmitkRenderWindow.cpp
@@ -89,96 +89,58 @@ void QmitkRenderWindow::LayoutDesignListChanged(int layoutDesignIndex)
     m_MenuWidget->UpdateLayoutDesignList(layoutDesignIndex);
 }
 
-void QmitkRenderWindow::mousePressEvent(QMouseEvent *me)
+
+bool QmitkRenderWindow::event(QEvent* e)
 {
-  // Get mouse position in vtk display coordinate system. me contains qt display infos...
-  mitk::Point2D displayPos = GetMousePosition(me);
-
-  mitk::MousePressEvent::Pointer mPressEvent =
-    mitk::MousePressEvent::New(m_Renderer, displayPos, GetButtonState(me), GetModifiers(me), GetEventButton(me));
-
-  if (!this->HandleEvent(mPressEvent.GetPointer()))
+  mitk::InteractionEvent::Pointer mitkEvent = nullptr;
+  switch (e->type())
   {
-    QVTKOpenGLWidget::mousePressEvent(me);
+    case QEvent::MouseMove:
+    {
+      auto me = static_cast<QMouseEvent *>(e);
+      mitkEvent = mitk::MouseMoveEvent::New(m_Renderer, GetMousePosition(me), GetButtonState(me), GetModifiers(me));
+      break;
+    }
+    case QEvent::MouseButtonPress:
+    {
+      auto me = static_cast<QMouseEvent *>(e);
+      mitkEvent = mitk::MousePressEvent::New( m_Renderer, GetMousePosition(me), GetButtonState(me), GetModifiers(me), GetEventButton(me));
+      break;
+    }
+    case QEvent::MouseButtonRelease:
+    {
+      auto me = static_cast<QMouseEvent *>(e);
+      mitkEvent = mitk::MouseReleaseEvent::New( m_Renderer, GetMousePosition(me), GetButtonState(me), GetModifiers(me), GetEventButton(me));
+      break;
+    }
+    case QEvent::MouseButtonDblClick:
+    {
+      auto me = static_cast<QMouseEvent *>(e);
+      mitkEvent = mitk::MouseDoubleClickEvent::New( m_Renderer, GetMousePosition(me), GetButtonState(me), GetModifiers(me), GetEventButton(me));
+      break;
+    }
+    case QEvent::Wheel:
+    {
+      auto we = static_cast<QWheelEvent *>(e);
+      mitkEvent = mitk::MouseWheelEvent::New( m_Renderer, GetMousePosition(we), GetButtonState(we), GetModifiers(we), GetDelta(we));
+      break;
+    }
+    case QEvent::KeyPress:
+    {
+      auto ke = static_cast<QKeyEvent*>(e);
+      mitkEvent = mitk::InteractionKeyEvent::New(m_Renderer, GetKeyLetter(ke), GetModifiers(ke));
+      break;
+    }
   }
 
-  if (m_ResendQtEvents)
-    me->ignore();
-}
-
-void QmitkRenderWindow::mouseDoubleClickEvent(QMouseEvent *me)
-{
-  mitk::Point2D displayPos = GetMousePosition(me);
-  mitk::MouseDoubleClickEvent::Pointer mPressEvent =
-    mitk::MouseDoubleClickEvent::New(m_Renderer, displayPos, GetButtonState(me), GetModifiers(me), GetEventButton(me));
-
-  if (!this->HandleEvent(mPressEvent.GetPointer()))
+  if (mitkEvent != nullptr)
   {
-    QVTKOpenGLWidget::mousePressEvent(me);
+    if (this->HandleEvent(mitkEvent.GetPointer())) {
+      return m_ResendQtEvents ? false : true;
+    }
   }
 
-  if (m_ResendQtEvents)
-    me->ignore();
-}
-
-void QmitkRenderWindow::mouseReleaseEvent(QMouseEvent *me)
-{
-  mitk::Point2D displayPos = GetMousePosition(me);
-  mitk::MouseReleaseEvent::Pointer mReleaseEvent =
-    mitk::MouseReleaseEvent::New(m_Renderer, displayPos, GetButtonState(me), GetModifiers(me), GetEventButton(me));
-
-  if (!this->HandleEvent(mReleaseEvent.GetPointer()))
-  {
-    QVTKOpenGLWidget::mouseReleaseEvent(me);
-  }
-
-  if (m_ResendQtEvents)
-    me->ignore();
-}
-
-void QmitkRenderWindow::mouseMoveEvent(QMouseEvent *me)
-{
-  mitk::Point2D displayPos = GetMousePosition(me);
-
-  this->AdjustRenderWindowMenuVisibility(me->pos());
-
-  mitk::MouseMoveEvent::Pointer mMoveEvent =
-    mitk::MouseMoveEvent::New(m_Renderer, displayPos, GetButtonState(me), GetModifiers(me));
-
-  if (!this->HandleEvent(mMoveEvent.GetPointer()))
-  {
-    QVTKOpenGLWidget::mouseMoveEvent(me);
-  }
-}
-
-void QmitkRenderWindow::wheelEvent(QWheelEvent *we)
-{
-  mitk::Point2D displayPos = GetMousePosition(we);
-  mitk::MouseWheelEvent::Pointer mWheelEvent =
-    mitk::MouseWheelEvent::New(m_Renderer, displayPos, GetButtonState(we), GetModifiers(we), GetDelta(we));
-
-  if (!this->HandleEvent(mWheelEvent.GetPointer()))
-  {
-    QVTKOpenGLWidget::wheelEvent(we);
-  }
-
-  if (m_ResendQtEvents)
-    we->ignore();
-}
-
-void QmitkRenderWindow::keyPressEvent(QKeyEvent *ke)
-{
-  mitk::InteractionEvent::ModifierKeys modifiers = GetModifiers(ke);
-  std::string key = GetKeyLetter(ke);
-
-  mitk::InteractionKeyEvent::Pointer keyEvent = mitk::InteractionKeyEvent::New(m_Renderer, key, modifiers);
-  if (!this->HandleEvent(keyEvent.GetPointer()))
-  {
-    QVTKOpenGLWidget::keyPressEvent(ke);
-  }
-
-  if (m_ResendQtEvents)
-    ke->ignore();
+  return QVTKOpenGLWidget::event(e);
 }
 
 void QmitkRenderWindow::enterEvent(QEvent *e)


### PR DESCRIPTION
Previous code broke betweeen MITK 2016.011 and 2018.04 due to
changes in VTK's QVTKOpenGLWidget. In 2016.11 QmitkRenderwindow
was checking all Qt events relevant for MITK's interaction
framework. QmitkRenderwindow decided whether the event shall
be treated by MITK or not - forwarding the event to VTK in the latter
case.

With changes to VTK's QVTKOpenGLWidget the above logic was not working
anymore. QVTKOpenGLWidget was getting to see relevant Qt events first,
e.g. mouse wheel events. Consequently, MITK interactors still got to
treat wheel events but could no longer prevent VTK from processing them
as well. That lead to behavior such as 'some MITK paint brush interactor
changes brush size' _and_ VTK's 3D camera interactor changes the zoom
level at the same time - wherase you would only one or the other
reaction.

The present change implements QmitkRenderwindow::event() which will now
get all Qt events first. QmitkRenderwindow::event() then decides on
further treatment as it was intended in the first place.

Signed-off-by: Daniel Maleike <daniel.maleike@stryker.com>