### PR TITLE
T28616: Add option to visualize point sets as fixed-size markers

### DIFF
--- a/Modules/Core/include/mitkPointSetVtkMapper2D.h
+++ b/Modules/Core/include/mitkPointSetVtkMapper2D.h
@@ -205,6 +205,9 @@ namespace mitk
     * displayed e.g. toggle visiblity of the propassembly */
     void ResetMapper(BaseRenderer *renderer) override;
 
+    /** \brief Determine a renderer's resolution in mm per screen pixel. */
+    double GetScreenResolution(const mitk::BaseRenderer *renderer) const;
+
     /* \brief Fills the vtk objects, thus it is only called when the point set has been changed.
    * This function iterates over the input point set and determines the glyphs which lie in a specific
    * range around the current slice. Those glyphs are rendered using a specific shape defined in vtk glyph source
@@ -231,6 +234,7 @@ namespace mitk
     int m_IDShapeProperty;        // ID for mitkPointSetShape Enumeration Property "Pointset.2D.shape"
     bool m_FillShape;             // "Pointset.2D.fill shape" property
     float m_DistanceToPlane;      // "Pointset.2D.distance to plane" property
+    bool m_FixedSizeOnScreen;     // "Pointset.2D.fixed size on screen" property
   };
 
 } // namespace mitk


### PR DESCRIPTION
Added an option to render point set markers as fixed-size glyphs on the
screen to improve visualization at very high zoom levels. When this
option is turned on, marker sizes are interpreted in screen pixels
rather than world coordinates.

Signed-off-by: Sven J Lafebre <s.lafebre@runbox.com>