### PR TITLE
Fix SurfaceToImageFilter not keep original values and Add reverse stencil support

### DIFF
--- a/Modules/Core/include/mitkSurfaceToImageFilter.h
+++ b/Modules/Core/include/mitkSurfaceToImageFilter.h
@@ -33,7 +33,7 @@ namespace mitk
    * binary image by setting MakeBinaryOutputOn (default is \a false). If
    * set to \a true all voxels inside the surface are set to one and all
    * outside voxel are set to zero.
-
+   *
    * The user can decide if he wants to keep the original values 
    * inside or outside the surface by setting ReverseStencil true (default is \a false). 
    * If set to \a true all voxels inside the surface are set to backGroundValue and all

--- a/Modules/Core/include/mitkSurfaceToImageFilter.h
+++ b/Modules/Core/include/mitkSurfaceToImageFilter.h
@@ -33,6 +33,11 @@ namespace mitk
    * binary image by setting MakeBinaryOutputOn (default is \a false). If
    * set to \a true all voxels inside the surface are set to one and all
    * outside voxel are set to zero.
+
+   * The user can decide if he wants to keep the original values 
+   * inside or outside the surface by setting ReverseStencil true (default is \a false). 
+   * If set to \a true all voxels inside the surface are set to backGroundValue and all
+   * outside voxel keep the original values of input Image.
    *
    * NOTE: Since the reference input image is passed to the vtkStencil in
    * any case, the image needs to be initialized with pixel values greater than
@@ -63,6 +68,9 @@ namespace mitk
     itkGetConstMacro(Tolerance, double);
     itkSetMacro(Tolerance, double);
 
+    itkSetMacro(ReverseStencil, bool);
+    itkGetMacro(ReverseStencil, bool);
+
     void GenerateInputRequestedRegion() override;
 
     void GenerateOutputInformation() override;
@@ -90,6 +98,8 @@ namespace mitk
 
     float m_BackgroundValue;
     double m_Tolerance;
+
+    bool m_ReverseStencil;
   };
 
 } // namespace mitk

--- a/Modules/Core/src/Algorithms/mitkSurfaceToImageFilter.cpp
+++ b/Modules/Core/src/Algorithms/mitkSurfaceToImageFilter.cpp
@@ -26,7 +26,7 @@ found in the LICENSE file.
 #include <vtkTransformPolyDataFilter.h>
 
 mitk::SurfaceToImageFilter::SurfaceToImageFilter()
-  : m_MakeOutputBinary(false), m_UShortBinaryPixelType(false), m_BackgroundValue(-10000), m_Tolerance(0.0)
+  : m_MakeOutputBinary(false), m_UShortBinaryPixelType(false), m_BackgroundValue(-10000), m_Tolerance(0.0)，m_ReverseStencil（false）
 {
 }
 
@@ -179,18 +179,13 @@ void mitk::SurfaceToImageFilter::Stencil3DImage(int time)
     vtkImageData *image = m_MakeOutputBinary ? binaryImage->GetVtkImageData() :
                                                const_cast<mitk::Image *>(this->GetImage())->GetVtkImageData(time);
 
-    // fill the image with foreground voxels:
-    unsigned char inval = 1;
-    vtkIdType count = image->GetNumberOfPoints();
-    for (vtkIdType i = 0; i < count; ++i)
-    {
-      image->GetPointData()->GetScalars()->SetTuple1(i, inval);
-    }
-
     // Create stencil and use numerical minimum of pixel type as background value
     vtkSmartPointer<vtkImageStencil> stencil = vtkSmartPointer<vtkImageStencil>::New();
     stencil->SetInputData(image);
-    stencil->ReverseStencilOff();
+    if (m_ReverseStencil)
+    {
+        stencil->ReverseStencilOn();
+    }
     stencil->ReleaseDataFlagOn();
     stencil->SetStencilConnection(surfaceConverter->GetOutputPort());
 


### PR DESCRIPTION
MakeOutputBinary is not working properly when setting to false. Original values can not be kept. Additionally,Users sometimes want to keep pixel values inside or outside the surface, ReverseStencil can easily make it happen.