### PR TITLE
Fix of bug T27260

### DIFF
--- a/Plugins/org.mitk.gui.qt.igt.app.ultrasoundtrackingnavigation/src/internal/QmitkUltrasoundCalibration.cpp
+++ b/Plugins/org.mitk.gui.qt.igt.app.ultrasoundtrackingnavigation/src/internal/QmitkUltrasoundCalibration.cpp
@@ -95,7 +95,8 @@ QmitkUltrasoundCalibration::~QmitkUltrasoundCalibration()
     this->GetDataStorage()->Remove(node);
 
   this->GetDataStorage()->Remove(m_VerificationReferencePointsDataNode);
-
+  this->GetDataStorage()->Remove(m_SpacingNode);
+  
   delete m_Timer;
 
   // remove observer for phantom-based point adding


### PR DESCRIPTION
Removed m_SpacingNodes out of dataStorage upon closing of IGT USTrackingNavigationCalibration view.