### PR TITLE
Avoid crashes in point picking when VTK props are deleted

### DIFF
--- a/Modules/Core/include/mitkVtkPropRenderer.h
+++ b/Modules/Core/include/mitkVtkPropRenderer.h
@@ -197,6 +197,7 @@ namespace mitk
 
   private:
     vtkSmartPointer<vtkAssemblyPaths> m_Paths;
+    vtkSmartPointer<vtkCollection> m_PickingProps;
     vtkTimeStamp m_PathTime;
 
     // prepare all mitk::mappers for rendering

--- a/Modules/Core/src/Rendering/mitkVtkPropRenderer.cpp
+++ b/Modules/Core/src/Rendering/mitkVtkPropRenderer.cpp
@@ -549,6 +549,11 @@ void mitk::VtkPropRenderer::UpdatePaths()
   {
     // Create the list to hold all the paths
     m_Paths = vtkSmartPointer<vtkAssemblyPaths>::New();
+    // m_Paths is collecting a list of vtkProps of all our mappers. However it does NOT ensure that these
+    // props are kept alive via a smart pointer. This can lead to situations where a mapper
+    // (with its prop(s)) is deleted and picking happens including this deleted prop.
+    // To avoid this, m_PickingProps was introduced to ensure that all props referenced by m_Paths are kept alive.
+    m_PickingProps = vtkSmartPointer<vtkCollection>::New();
 
     DataStorage::SetOfObjects::ConstPointer objects = m_DataStorage->GetAll();
     for (auto iter = objects->begin(); iter != objects->end(); ++iter)
@@ -567,6 +572,7 @@ void mitk::VtkPropRenderer::UpdatePaths()
             // add to assembly path
             onePath->AddNode(prop, prop->GetMatrix());
             m_Paths->AddItem(onePath);
+            m_PickingProps->AddItem(prop);
           }
         }
       }


### PR DESCRIPTION
I could observe crashes where mappers were deleted and subsequent picking
was then attempting to access some of the deleted vtkProps associated
to the deleted mappers.

I do not see a way to improve the mtime checks in this method to avoid
the aforementioned crash. So the only way to ensure proper picking seems
to be the introduction of a new list of pointers to props so the props
are not getting deleted.

Signed-off-by: Daniel Maleike <daniel.maleike@stryker.com>