### PR TITLE
Fix typos in Modules/DICOM

### DIFF
--- a/Modules/DICOM/TODOs.txt
+++ b/Modules/DICOM/TODOs.txt
@@ -39,7 +39,7 @@ Important
         Solution: GetTagValue as String does a right-trim plus we check after conversion! Works.
 [x] Implement Configurator::GetBuiltIn3DReaders() (don't ignore "classic reader")
 [x] Complete MITK properties of images: level/window and color type (MONOCHROME1/2)
-[x] Check input images fo DICOMness and non-multi-frameness
+[x] Check input images for DICOMness and non-multi-frameness
 [x] Use CanHandleFile() in selection!
     - implicitly now, the reader checks itself and produces no output if it cannot handle the files
 [x] Check ToDo in mitkDICOMTag.cpp

--- a/Modules/DICOM/autoload/DICOMImageIO/include/mitkDICOMTagsOfInterestService.h
+++ b/Modules/DICOM/autoload/DICOMImageIO/include/mitkDICOMTagsOfInterestService.h
@@ -26,7 +26,7 @@ namespace mitk
    * \brief DICOM tags of interest service.
    *
    * This service allows you to manage the tags of interest (toi).
-   * All registred toi will be extracted when loading dicom data and stored as properties in the corresponding
+   * All registered toi will be extracted when loading dicom data and stored as properties in the corresponding
    * base data object. In addition the service can (if available) use IPropertyPersistance and IPropertyDescriptions
    * to ensure that the tags of interests are also persisted and have a human readable descriptions.
    */

--- a/Modules/DICOM/include/mitkClassicDICOMSeriesReader.h
+++ b/Modules/DICOM/include/mitkClassicDICOMSeriesReader.h
@@ -25,7 +25,7 @@ namespace mitk
   \brief Sorting and grouping like mitk::DicomSeriesReader until 2013.
 
   This class implements the same functionality as the legacy class DicomSeriesReader,
-  except that is is 75 lines instead of 2500 lines.
+  except that it is 75 lines instead of 2500 lines.
   \warning Since the old class is known to have problems with some series,
            it is advised to use a good configuration of DICOMITKSeriesGDCMReader,
            which can be obtained by using DICOMFileReaderSelector.
@@ -44,8 +44,8 @@ namespace mitk
 
   Within each of the groups, datasets are sorted by the value of the following tags (primary sorting first):
    - (0020,0032) %Image Position (Patient) (distance from zero along normal of (0020,0037) %Image Orientation (Patient))
-   - (0020,0012) Aqcuisition Number
-   - (0008,0032) Aqcuisition Time
+   - (0020,0012) Acquisition Number
+   - (0008,0032) Acquisition Time
    - (0018,1060) Trigger Time
    - (0008,0018) SOP Instance UID (last resort, not really meaningful but decides clearly)
 

--- a/Modules/DICOM/include/mitkDICOMDCMTKTagScanner.h
+++ b/Modules/DICOM/include/mitkDICOMDCMTKTagScanner.h
@@ -49,7 +49,7 @@ namespace mitk
       */
       void AddTagPath(const DICOMTagPath& tag) override;
       /**
-      \brief Add a list of tag pathes to the scanning process.
+      \brief Add a list of tag paths to the scanning process.
       */
       void AddTagPaths(const DICOMTagPathList& tags) override;
 

--- a/Modules/DICOM/include/mitkDICOMDatasetAccess.h
+++ b/Modules/DICOM/include/mitkDICOMDatasetAccess.h
@@ -52,14 +52,14 @@ class MITKDICOM_EXPORT DICOMDatasetAccess
     virtual std::string GetFilenameIfAvailable() const = 0;
 
     /** \brief Return a DICOMDatasetFinding instance of the tag.
-    The return containes (if valid) the raw value of the tag as a string.
-    \param tag Tag which value should be retreived.
+    The return contains (if valid) the raw value of the tag as a string.
+    \param tag Tag which value should be retrieved.
     */
     virtual DICOMDatasetFinding GetTagValueAsString(const DICOMTag& tag) const = 0;
 
     /** \brief Return a list of DICOMDatasetFindings of the passed tag path.
-    The return containes (if valid) the raw value of the tag as a string.
-    \param path Tag path which value should be retreived.
+    The return contains (if valid) the raw value of the tag as a string.
+    \param path Tag path which value should be retrieved.
     */
     virtual FindingsListType GetTagValueAsString(const DICOMTagPath& path) const = 0;
 

--- a/Modules/DICOM/include/mitkDICOMDatasetSorter.h
+++ b/Modules/DICOM/include/mitkDICOMDatasetSorter.h
@@ -29,7 +29,7 @@ namespace mitk
   described as part of DICOMITKSeriesGDCMReader::AnalyzeInputFiles()
   (see \ref DICOMITKSeriesGDCMReader_LoadingStrategy).
 
-  The prodecure is simple:
+  The procedure is simple:
    - take a list of input datasets (DICOMDatasetAccess)
    - sort them (to be defined by sub-classes, based on specific tags)
    - return the sorting result as outputs (the single input might be distributed into multiple outputs)

--- a/Modules/DICOM/include/mitkDICOMEnums.h
+++ b/Modules/DICOM/include/mitkDICOMEnums.h
@@ -48,7 +48,7 @@ namespace mitk
   typedef enum
   {
     SOPClassSupported,       ///< loader code and tests are established
-    SOPClassPartlySupported, ///< loader code and tests are establised for specific parts of a SOP Class
+    SOPClassPartlySupported, ///< loader code and tests are established for specific parts of a SOP Class
     SOPClassImplemented,     ///< loader code is implemented but not accompanied by tests
     SOPClassUnsupported,     ///< loader code is not known to work with this SOP Class
     SOPClassUnknown,         ///< loader did not yet inspect any images, unknown fitness

--- a/Modules/DICOM/include/mitkDICOMFileReader.h
+++ b/Modules/DICOM/include/mitkDICOMFileReader.h
@@ -107,7 +107,7 @@ public:
    * Empty value is default and will imply to use the found DICOMTagPath as property name.*/
   typedef DICOMImageBlockDescriptor::AdditionalTagsMapType AdditionalTagsMapType;
   /**
-  * \brief Set a list of DICOMTagPaths that specifiy all DICOM-Tags that will be copied into the property of the mitk::Image.
+  * \brief Set a list of DICOMTagPaths that specify all DICOM-Tags that will be copied into the property of the mitk::Image.
   *
   * This method can be used to specify a list of DICOM-tags that shall be available after the loading.
   * The value in the tagMap is an optional user defined name for the property key that should be used

--- a/Modules/DICOM/include/mitkDICOMGDCMTagScanner.h
+++ b/Modules/DICOM/include/mitkDICOMGDCMTagScanner.h
@@ -66,7 +66,7 @@ namespace mitk
       */
       void AddTagPath(const DICOMTagPath& tag) override;
       /**
-      \brief Add a list of tag pathes to the scanning process.
+      \brief Add a list of tag paths to the scanning process.
       */
       void AddTagPaths(const DICOMTagPathList& tags) override;
 

--- a/Modules/DICOM/include/mitkDICOMITKSeriesGDCMReader.h
+++ b/Modules/DICOM/include/mitkDICOMITKSeriesGDCMReader.h
@@ -98,7 +98,7 @@ namespace mitk
   \section DICOMITKSeriesGDCMReader_GantryTilt Gantry tilt handling
 
   When CT gantry tilt is used, the gantry plane (= X-Ray source and detector ring) and the vertical plane do not align
-  anymore. This scanner feature is used for example to reduce metal artifacs (e.g. <i>Lee C , Evaluation of Using CT
+  anymore. This scanner feature is used for example to reduce metal artifacts (e.g. <i>Lee C , Evaluation of Using CT
   Gantry Tilt Scan on Head and Neck Cancer Patients with Dental Structure: Scans Show Less Metal Artifacts. Presented
   at: Radiological Society of North America 2011 Scientific Assembly and Annual Meeting; November 27- December 2,
   2011 Chicago IL.</i>).

--- a/Modules/DICOM/include/mitkDICOMImageBlockDescriptor.h
+++ b/Modules/DICOM/include/mitkDICOMImageBlockDescriptor.h
@@ -157,7 +157,7 @@ namespace mitk
     /// SOP Class as human readable name (e.g. "CT Image Storage")
     std::string GetSOPClassUIDAsName() const;
 
-    /**Convinience method that returns the property timesteps*/
+    /**Convenience method that returns the property timesteps*/
     int GetNumberOfTimeSteps() const;
     /**return the number of frames that constitute one timestep.*/
     int GetNumberOfFramesPerTimeStep() const;
@@ -169,7 +169,7 @@ namespace mitk
     * Empty value is default and will imply to use the found DICOMTagPath as property name.*/
     typedef std::map<DICOMTagPath, std::string> AdditionalTagsMapType;
     /**
-    * \brief Set a list of DICOMTagPaths that specifiy all DICOM-Tags that will be copied into the property of the mitk::Image.
+    * \brief Set a list of DICOMTagPaths that specify all DICOM-Tags that will be copied into the property of the mitk::Image.
     *
     * This method can be used to specify a list of DICOM-tags that shall be available after the loading.
     * The value in the tagMap is an optional user defined name for the property key that should be used

--- a/Modules/DICOM/include/mitkDICOMReaderConfigurator.h
+++ b/Modules/DICOM/include/mitkDICOMReaderConfigurator.h
@@ -78,7 +78,7 @@ namespace mitk
 
   This first version is hard coded for the current state of the implementation.
 
-  If things should evolve in a way that needs us to splitt off readers for "old" versions,
+  If things should evolve in a way that needs us to split off readers for "old" versions,
   time should be taken to refactor this class.
 
   Basically, a serializer class should accompany each of the configurable classes. Such

--- a/Modules/DICOM/include/mitkDICOMSortByTag.h
+++ b/Modules/DICOM/include/mitkDICOMSortByTag.h
@@ -26,7 +26,7 @@ namespace mitk
    1. numerical value if possible (i.e. both datasets have a value that is numerical)
    2. alphabetical order otherwise
 
-  If the comparison results in equalness, it is refered to the secondary criterion, see
+  If the comparison results in equalness, it is referred to the secondary criterion, see
   DICOMSortByTag::NextLevelIsLeftBeforeRight().
 
 */

--- a/Modules/DICOM/include/mitkDICOMSortCriterion.h
+++ b/Modules/DICOM/include/mitkDICOMSortCriterion.h
@@ -30,9 +30,9 @@ namespace mitk
   Each time IsLeftBeforeRight() is called, the method should return whether
   the left dataset should be sorted before the right dataset.
 
-  Because there are identical tags values quite oftenly, a DICOMSortCriterion
+  Because there are identical tags values quite often, a DICOMSortCriterion
   will always hold a secondary DICOMSortCriterion. In cases of equal tag
-  values, the decision is refered to the secondary criterion.
+  values, the decision is referred to the secondary criterion.
 */
 class MITKDICOM_EXPORT DICOMSortCriterion : public itk::LightObject
 {

--- a/Modules/DICOM/include/mitkDICOMTagPath.h
+++ b/Modules/DICOM/include/mitkDICOMTagPath.h
@@ -40,7 +40,7 @@ namespace mitk
     {
       enum class NodeType
       {
-        Invalid = 0,  //*< Node is non existant or invalid.
+        Invalid = 0,  //*< Node is non existent or invalid.
         Element,  //*< Selects an specific element given the node name.
         SequenceSelection, //*< Selects an specific item in a sequence of items and has a item selector ("[n]").
         AnySelection, //*< Selects all items of a specific element ("[*]").
@@ -126,7 +126,7 @@ namespace mitk
 
     /**Checks if to DICOMTagPathes are specify the same node. Hence all wildcards will be processed.\n
     * E.G.: "item1/child1/grandChild2" == ".//item1//grandChild2" is true.
-    * \remark If you want to check if to pathes are "truely" equal and not only equal in terms of
+    * \remark If you want to check if two paths are "truly" equal and not only equal in terms of
     * pointing to the same node, use the member function Equals()*/
     bool Equals(const DICOMTagPath& path) const;
 

--- a/Modules/DICOM/include/mitkDICOMTagScanner.h
+++ b/Modules/DICOM/include/mitkDICOMTagScanner.h
@@ -57,7 +57,7 @@ namespace mitk
       */
       virtual void AddTagPath(const DICOMTagPath& path) = 0;
       /**
-      \brief Add a list of tag pathes to the scanning process.
+      \brief Add a list of tag paths to the scanning process.
       */
       virtual void AddTagPaths(const DICOMTagPathList& paths) = 0;
 

--- a/Modules/DICOM/include/mitkEquiDistantBlocksSorter.h
+++ b/Modules/DICOM/include/mitkEquiDistantBlocksSorter.h
@@ -37,11 +37,11 @@ namespace mitk
 
  Slices that share a position in space are also sorted into separate blocks during this step.
  So the result of this step is a set of blocks that contain only slices with equal z spacing
- and uniqe slices at each position.
+ and unique slices at each position.
 
  During sorting, the origins (documented in tag image position patient) are compared
  against expected origins (from former origin plus moving direction). As there will
- be minor differences in numbers (from both calculations and unprecise tag values),
+ be minor differences in numbers (from both calculations and imprecise tag values),
  we must be a bit tolerant here. The default behavior is to expect that an origin is
  not further away from the expected position than 30% of the inter-slice distance.
  To support a legacy behavior of a former loader (DicomSeriesReader), this default can
@@ -128,7 +128,7 @@ class MITKDICOM_EXPORT EquiDistantBlocksSorter : public DICOMDatasetSorter
         DICOMDatasetList GetUnsortedDatasets();
 
         /**
-          \brief Wheter or not the grouped result contain a gantry tilt.
+          \brief Whether or not the grouped result contain a gantry tilt.
          */
         bool ContainsGantryTilt();
 

--- a/Modules/DICOM/include/mitkGantryTiltInformation.h
+++ b/Modules/DICOM/include/mitkGantryTiltInformation.h
@@ -27,7 +27,7 @@ namespace mitk
   Takes geometry information for two slices of a DICOM series and
   calculates whether these fit into an orthogonal block or not.
   If NOT, they can either be the result of an acquisition with
-  gantry tilt OR completly broken by some shearing transformation.
+  gantry tilt OR completely broken by some shearing transformation.
 
   Most calculations are done in the constructor, results can then
   be read via the remaining methods.
@@ -95,7 +95,7 @@ class GantryTiltInformation
 
       Gantry tilt will only produce shifts in ONE orientation, not in both.
 
-      Since the correction code currently only coveres one tilt direction
+      Since the correction code currently only covers one tilt direction
       AND we don't know of medical images with two tilt directions, the
       loading code wants to check if our assumptions are true.
      */

--- a/Modules/DICOM/include/mitkIDICOMTagsOfInterest.h
+++ b/Modules/DICOM/include/mitkIDICOMTagsOfInterest.h
@@ -26,7 +26,7 @@ namespace mitk
    * \brief Interface of DICOM tags of interest service.
    *
    * This service allows you to manage the tags of interest (toi).
-   * All registred toi will be extracted when loading dicom data and stored as properties in the corresponding
+   * All registered toi will be extracted when loading dicom data and stored as properties in the corresponding
    * base data object. In addition the service can (if available) use IPropertyPersistance and IPropertyAliases
    * to ensure that the tags of interests are also persisted and have a human readable alias.
    */
@@ -38,7 +38,7 @@ namespace mitk
     /** \brief Add an tag to the TOI.
       * If the tag was already added it will be overwritten with the passed values.
       * \param[in] tag Tag that should be added.
-      * \param[in] makePersistant Indicates if the tag should be made persistant if possible via the IPropertyPersistence service.
+      * \param[in] makePersistant Indicates if the tag should be made persistent if possible via the IPropertyPersistence service.
       */
     virtual void AddTagOfInterest(const DICOMTagPath& tag, bool makePersistant = true) = 0;
 

--- a/Modules/DICOM/include/mitkITKDICOMSeriesReaderHelper.h
+++ b/Modules/DICOM/include/mitkITKDICOMSeriesReaderHelper.h
@@ -59,7 +59,7 @@ class ITKDICOMSeriesReaderHelper
       DateTimeBounds& bounds, TimeBounds& triggerBounds);
 
     /* Determine the time bounds in ms respective to the baselineDateTime for the passed
-    files. Additionaly it regards the trigger time tag if set and acquisition date time
+    files. Additionally it regards the trigger time tag if set and acquisition date time
     carries not enough information.*/
     static bool ExtractTimeBoundsOfTimeStep(const StringContainer& filenamesOfTimeStep,
                                                  TimeBounds& bounds,

--- a/Modules/DICOM/include/mitkITKDICOMSeriesReaderHelper.txx
+++ b/Modules/DICOM/include/mitkITKDICOMSeriesReaderHelper.txx
@@ -258,7 +258,7 @@ mitk::ITKDICOMSeriesReaderHelper
 
   // if tilt positive, then we need additional pixels BELOW origin, otherwise we need pixels behind the end of the block
 
-  // in any case we need more size to accomodate shifted slices
+  // in any case we need more size to accommodate shifted slices
   typename ImageType::SizeType largerSize = resampler->GetSize(); // now the resampler already holds the input image's size.
   const double imageSizeZ = largerSize[2];
   //MITK_DEBUG <<"Calculate lager size = " << largerSize[1] << " + " << tiltInfo.GetTiltCorrectedAdditionalSize(imageSizeZ) << " / " << input->GetSpacing()[1] << "+ 2.0";

--- a/Modules/DICOM/resource/configurations/3D/imagetime.xml
+++ b/Modules/DICOM/resource/configurations/3D/imagetime.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" standalone="no"?>
 <DICOMFileReader
   label="Image Time"
-  description="Sort images by Acqusition Time"
+  description="Sort images by Acquisition Time"
   class="DICOMITKSeriesGDCMReader"
   version="2"
   fixTiltByShearing="true">

--- a/Modules/DICOM/resource/configurations/3DnT/imageposition.xml
+++ b/Modules/DICOM/resource/configurations/3DnT/imageposition.xml
@@ -3,7 +3,7 @@
   class="ThreeDnTDICOMSeriesReader"
   version="2"
   label="IPP 3D+t"
-  description="Sort by Image Position (Patient), then group as 3D+t (till 2018/03 this configuration was wrongly stored in the file classicreader.xml (verison 1))"
+  description="Sort by Image Position (Patient), then group as 3D+t (till 2018/03 this configuration was wrongly stored in the file classicreader.xml (version 1))"
   group3DnT="true"
   fixTiltByShearing="true">
 <DICOMDatasetSorter class="DICOMTagBasedSorter" strictSorting="true" expectDistanceOne="true">

--- a/Modules/DICOM/src/legacy/mitkDicomSeriesReader.cpp
+++ b/Modules/DICOM/src/legacy/mitkDicomSeriesReader.cpp
@@ -74,7 +74,7 @@ namespace mitk
       /*
          Selection criteria:
          - no sequences because we cannot represent that
-         - nothing animal related (specied, breed registration number), MITK focusses on human medical image processing.
+         - nothing animal related (specified, breed registration number), MITK focuses on human medical image processing.
          - only general attributes so far
 
          When extending this, we should make use of a real dictionary (GDCM/DCMTK and lookup the tag names there)
@@ -260,7 +260,7 @@ namespace mitk
     gdcm::StringFilter sf;
     sf.SetFile(reader.GetFile());
 
-    gdcm::Attribute<0x0028, 0x0011> dimTagX; // coloumns || sagittal
+    gdcm::Attribute<0x0028, 0x0011> dimTagX;   // columns || sagittal
     gdcm::Attribute<0x3001, 0x1001, gdcm::VR::UL, gdcm::VM::VM1>
       dimTagZ;                                 // I have no idea what is VM1. // (Philips specific) // axial
     gdcm::Attribute<0x0028, 0x0010> dimTagY;   // rows || coronal
@@ -352,12 +352,12 @@ namespace mitk
 
     while (!iterator.IsAtEnd())
     {
-      unsigned long adressedPixel =
+      unsigned long addressedPixel =
         pixCount +
-        (numberOfSlices - 1 - planeCount) * planeSize // add offset to adress the first pixel of current plane
+        (numberOfSlices - 1 - planeCount) * planeSize // add offset to address the first pixel of current plane
         + timeCount * numberOfSlices * planeSize;     // add time offset
 
-      iterator.Set(new_pixels[adressedPixel]);
+      iterator.Set(new_pixels[addressedPixel]);
       pixCount++;
       ++iterator;
 
@@ -935,7 +935,7 @@ namespace mitk
             bool identicalOrigins;
             try
             {
-              // check whether this and the previous block share a comon origin
+              // check whether this and the previous block share a common origin
               // TODO should be safe, but a little try/catch or other error handling wouldn't hurt
 
               const char *origin_value = scanner.GetValue(groupsOf3DBlocks[thisBlockKey].GetFilenames().front().c_str(),
@@ -1070,7 +1070,7 @@ namespace mitk
     constructedID += CreateSeriesIdentifierPart(tagValueMap, tagSliceThickness);
     constructedID += CreateSeriesIdentifierPart(tagValueMap, tagNumberOfFrames);
 
-    // be a bit tolerant for orienatation, let only the first few digits matter
+    // be a bit tolerant for orientation, let only the first few digits matter
     // (http://bugs.mitk.org/show_bug.cgi?id=12263)
     // NOT constructedID += CreateSeriesIdentifierPart( tagValueMap, tagImageOrientation );
     if (tagValueMap.find(tagImageOrientation) != tagValueMap.end())
@@ -1427,7 +1427,7 @@ namespace mitk
     // Copy tags for series, study, patient level (leave interpretation to application).
     // These properties will be copied to the DataNode by DicomSeriesReader.
 
-    // tags for the series (we just use the one that ITK copied to its dictionary (proably that of the last slice)
+    // tags for the series (we just use the one that ITK copied to its dictionary (probably that of the last slice)
     const itk::MetaDataDictionary &dict = io->GetMetaDataDictionary();
     const TagToPropertyMapType &propertyLookup = DicomSeriesReader::GetDICOMTagsToMITKPropertyMap();
 

--- a/Modules/DICOM/src/legacy/mitkDicomSeriesReader.h
+++ b/Modules/DICOM/src/legacy/mitkDicomSeriesReader.h
@@ -78,7 +78,7 @@ namespace mitk
    \b Assumptions
     - expected to work with certain SOP Classes (mostly CT Image Storage and MR Image Storage)
       - see ImageBlockDescriptor.GetReaderImplementationLevel() method for the details
-    - special treatment for a certain type of Philips 3D ultrasound (recogized by tag 3001,0010 set to "Philips3D")
+    - special treatment for a certain type of Philips 3D ultrasound (recognized by tag 3001,0010 set to "Philips3D")
     - loader will always attempt to read multiple single slices as a single 3D image volume (i.e. mitk::Image)
       - slices will be grouped by basic properties such as orientation, rows, columns, spacing and grouped into as large
   blocks as possible
@@ -166,7 +166,7 @@ namespace mitk
    Before slices are further analyzed, they are sorted spatially. As implemented by GdcmSortFunction(),
    slices are sorted by
      1. distance from origin (calculated using (0020,0032) Image Position Patient and (0020,0037) Image Orientation)
-     2. when distance is equal, (0020,0012) Aquisition Number, (0008,0032) Acquisition Time and (0018,1060) Trigger Time
+     2. when distance is equal, (0020,0012) Acquisition Number, (0008,0032) Acquisition Time and (0018,1060) Trigger Time
   are
         used as a backup criterions (necessary for meaningful 3D+t sorting)
 
@@ -188,7 +188,7 @@ namespace mitk
 
    Slices that share a position in space are also sorted into separate blocks during this step.
    So the result of this step is a set of blocks that contain only slices with equal z spacing
-   and uniqe slices at each position.
+   and unique slices at each position.
 
    \subsection DicomSeriesReader_sorting4 Step 4 (optional): group 3D blocks as 3D+t when possible
 
@@ -199,7 +199,7 @@ namespace mitk
    \section DicomSeriesReader_gantrytilt Handling of gantry tilt
 
    When CT gantry tilt is used, the gantry plane (= X-Ray source and detector ring) and the vertical plane do not align
-   anymore. This scanner feature is used for example to reduce metal artifacs (e.g. <i>Lee C , Evaluation of Using CT
+   anymore. This scanner feature is used for example to reduce metal artifacts (e.g. <i>Lee C , Evaluation of Using CT
    Gantry Tilt Scan on Head and Neck Cancer Patients with Dental Structure: Scans Show Less Metal Artifacts. Presented
    at: Radiological Society of North America 2011 Scientific Assembly and Annual Meeting; November 27- December 2,
    2011 Chicago IL.</i>).
@@ -299,7 +299,7 @@ namespace mitk
 
    \section DicomSeriesReader_pixelspacing Handling of pixel spacing
 
-   The reader implementes what is described in DICOM Part 3, chapter 10.7 (Basic Pixel Spacing Calibration Macro): Both
+   The reader implements what is described in DICOM Part 3, chapter 10.7 (Basic Pixel Spacing Calibration Macro): Both
   tags
     - (0028,0030) Pixel Spacing and
     - (0018,1164) Imager Pixel Spacing
@@ -321,7 +321,7 @@ namespace mitk
 
     This is a short list of ideas for enhancement:
      - Class has historically grown and should be reviewed again. There is probably too many duplicated scanning code
-     - Multi-frame images don't mix well with the curent assumption of "one file - one slice", which is assumed by our
+     - Multi-frame images don't mix well with the current assumption of "one file - one slice", which is assumed by our
   code
        - It should be checked how well GDCM and ITK support these files (some load, some don't)
      - Specializations such as the Philips 3D code should be handled in a more generic way. The current handling of
@@ -368,7 +368,7 @@ namespace mitk
     */
     typedef enum {
       ReaderImplementationLevel_Supported,       /// loader code and tests are established
-      ReaderImplementationLevel_PartlySupported, /// loader code and tests are establised for specific parts of a SOP
+      ReaderImplementationLevel_PartlySupported, /// loader code and tests are established for specific parts of a SOP
                                                  /// Class
       ReaderImplementationLevel_Implemented,     /// loader code is implemented but not accompanied by tests
       ReaderImplementationLevel_Unsupported,     /// loader code is not working with this SOP Class
@@ -618,7 +618,7 @@ namespace mitk
       StringContainer GetUnsortedFilenames();
 
       /**
-        \brief Wheter or not the grouped result contain a gantry tilt.
+        \brief Whether or not the grouped result contain a gantry tilt.
       */
       bool ContainsGantryTilt();
 
@@ -657,7 +657,7 @@ namespace mitk
       Takes geometry information for two slices of a DICOM series and
       calculates whether these fit into an orthogonal block or not.
       If NOT, they can either be the result of an acquisition with
-      gantry tilt OR completly broken by some shearing transformation.
+      gantry tilt OR completely broken by some shearing transformation.
 
       Most calculations are done in the constructor, results can then
       be read via the remaining methods.
@@ -708,7 +708,7 @@ namespace mitk
 
         Gantry tilt will only produce shifts in ONE orientation, not in both.
 
-        Since the correction code currently only coveres one tilt direction
+        Since the correction code currently only covers one tilt direction
         AND we don't know of medical images with two tilt directions, the
         loading code wants to check if our assumptions are true.
       */
@@ -816,7 +816,7 @@ namespace mitk
       \brief Sort a set of file names in an order that is meaningful for loading them into an mitk::Image.
 
       \warning This method assumes that input files are similar in basic properties such as
-               slice thicknes, image orientation, pixel spacing, rows, columns.
+               slice thickness, image orientation, pixel spacing, rows, columns.
                It should always be ok to put the result of a call to GetSeries(..) into this method.
 
       Sorting order is determined by

--- a/Modules/DICOM/src/legacy/mitkDicomSeriesReader.txx
+++ b/Modules/DICOM/src/legacy/mitkDicomSeriesReader.txx
@@ -260,7 +260,7 @@ namespace mitk
     // if tilt positive, then we need additional pixels BELOW origin, otherwise we need pixels behind the end of the
     // block
 
-    // in any case we need more size to accomodate shifted slices
+    // in any case we need more size to accommodate shifted slices
     typename ImageType::SizeType largerSize =
       resampler->GetSize(); // now the resampler already holds the input image's size.
     largerSize[1] += static_cast<typename ImageType::SizeType::SizeValueType>(

--- a/Modules/DICOM/src/mitkBaseDICOMReaderService.cpp
+++ b/Modules/DICOM/src/mitkBaseDICOMReaderService.cpp
@@ -121,7 +121,7 @@ std::vector<itk::SmartPointer<BaseData> > BaseDICOMReaderService::DoRead()
             auto finding = std::find_if(frameList.begin(), frameList.end(), [&](const DICOMImageFrameInfo::Pointer& frame) { return frame->Filename == fileName; });
 
             if (finding != frameList.end())
-            { //we have the block containing the fileName -> these are the realy relevant files.
+            { //we have the block containing the fileName -> these are the really relevant files.
               relevantFiles.resize(frameList.size());
               std::transform(frameList.begin(), frameList.end(), relevantFiles.begin(), [](const DICOMImageFrameInfo::Pointer& frame) { return frame->Filename; });
               break;

--- a/Modules/DICOM/src/mitkClassicDICOMSeriesReader.cpp
+++ b/Modules/DICOM/src/mitkClassicDICOMSeriesReader.cpp
@@ -30,8 +30,8 @@ mitk::ClassicDICOMSeriesReader
   // a sorter...
   mitk::DICOMSortCriterion::ConstPointer sorting =
     mitk::SortByImagePositionPatient::New( // image position patient and image orientation
-      mitk::DICOMSortByTag::New( DICOMTag(0x0020, 0x0012), // aqcuisition number
-        mitk::DICOMSortByTag::New( DICOMTag(0x0008, 0x0032), // aqcuisition time
+      mitk::DICOMSortByTag::New( DICOMTag(0x0020, 0x0012), // acquisition number
+        mitk::DICOMSortByTag::New( DICOMTag(0x0008, 0x0032), // acquisition time
           mitk::DICOMSortByTag::New( DICOMTag(0x0018, 0x1060), // trigger time
             mitk::DICOMSortByTag::New( DICOMTag(0x0008, 0x0018) // SOP instance UID (last resort, not really meaningful but decides clearly)
             ).GetPointer()

--- a/Modules/DICOM/src/mitkDICOMGDCMTagScanner.cpp
+++ b/Modules/DICOM/src/mitkDICOMGDCMTagScanner.cpp
@@ -59,7 +59,7 @@ void mitk::DICOMGDCMTagScanner::AddTagPath(const DICOMTagPath& path)
   {
     std::stringstream errorstring;
     errorstring << "Invalid call to DICOMGDCMTagScanner::AddTagPath(). "
-      << "Scanner does only support pathes that are explicitly specify one tag. "
+      << "Scanner does only support paths that are explicitly specify one tag. "
       << "Invalid path: "<<path.ToStr();
     MITK_ERROR << errorstring.str();
     throw std::invalid_argument(errorstring.str());
@@ -75,7 +75,7 @@ void mitk::DICOMGDCMTagScanner::AddTagPaths(const DICOMTagPathList& paths)
     {
       std::stringstream errorstring;
       errorstring << "Invalid call to DICOMGDCMTagScanner::AddTagPaths(). "
-        << "Scanner does only support pathes that are explicitly specify one tag. "
+        << "Scanner does only support paths that are explicitly specify one tag. "
         << "Invalid path: " << path.ToStr();
       MITK_ERROR << errorstring.str();
       throw std::invalid_argument(errorstring.str());

--- a/Modules/DICOM/src/mitkDICOMImageBlockDescriptor.cpp
+++ b/Modules/DICOM/src/mitkDICOMImageBlockDescriptor.cpp
@@ -436,7 +436,7 @@ double mitk::DICOMImageBlockDescriptor::stringtodouble( const std::string& str )
   }
   else
   {
-    throw std::invalid_argument( "Argument is not a convertable number" );
+    throw std::invalid_argument( "Argument is not a convertible number" );
   }
 }
 
@@ -483,7 +483,7 @@ mitk::Image::Pointer mitk::DICOMImageBlockDescriptor::DescribeImageWithPropertie
   /////////////////////////////////////////////////////////////////////////////
 
   // first part: add some tags that describe individual slices
-  // these propeties are defined at analysis time (see UpdateImageDescribingProperties())
+  // these properties are defined at analysis time (see UpdateImageDescribingProperties())
 
   const char* propertyKeySliceLocation  = "dicom.image.0020.1041";
   const char* propertyKeyInstanceNumber = "dicom.image.0020.0013";

--- a/Modules/DICOM/src/mitkDICOMSortByTag.cpp
+++ b/Modules/DICOM/src/mitkDICOMSortByTag.cpp
@@ -99,7 +99,7 @@ mitk::DICOMSortByTag
   DICOMDatasetFinding leftFinding = left->GetTagValueAsString(tag);
   DICOMDatasetFinding rightFinding = right->GetTagValueAsString(tag);
   //Doesn't care if findings are valid or not. If they are not valid,
-  //value is empty, thats enough.
+  //value is empty, that's enough.
   if (leftFinding.value != rightFinding.value)
   {
     return leftFinding.value.compare(rightFinding.value) < 0;
@@ -120,7 +120,7 @@ mitk::DICOMSortByTag
   const DICOMDatasetFinding leftFinding = left->GetTagValueAsString(tag);
   const DICOMDatasetFinding rightFinding = right->GetTagValueAsString(tag);
   //Doesn't care if findings are valid or not. If they are not valid,
-  //value is empty, thats enough.
+  //value is empty, that's enough.
 
   double leftDouble( 0 );
   double rightDouble( 0 );
@@ -156,7 +156,7 @@ mitk::DICOMSortByTag
   const DICOMDatasetFinding fromFinding = from->GetTagValueAsString(m_Tag);
   const DICOMDatasetFinding toFinding = to->GetTagValueAsString(m_Tag);
   //Doesn't care if findings are valid or not. If they are not valid,
-  //value is empty, thats enough.
+  //value is empty, that's enough.
 
   double fromDouble(0);
   double toDouble(0);

--- a/Modules/DICOM/src/mitkDICOMTagBasedSorter.cpp
+++ b/Modules/DICOM/src/mitkDICOMTagBasedSorter.cpp
@@ -31,7 +31,7 @@ std::string
 mitk::DICOMTagBasedSorter::CutDecimalPlaces
 ::operator()(const std::string& input) const
 {
-  // be a bit tolerant for tags such as image orientation orienatation, let only the first few digits matter (http://bugs.mitk.org/show_bug.cgi?id=12263)
+  // be a bit tolerant for tags such as image orientation orientation, let only the first few digits matter (http://bugs.mitk.org/show_bug.cgi?id=12263)
   // iterate all fields, convert each to a number, cut this number as configured, then return a concatenated string with all cut-off numbers
   std::ostringstream resultString;
   resultString.str(std::string());

--- a/Modules/DICOM/src/mitkDICOMTagsOfInterestAddHelper.cpp
+++ b/Modules/DICOM/src/mitkDICOMTagsOfInterestAddHelper.cpp
@@ -68,7 +68,7 @@ mitk::DICOMTagsOfInterestAddHelper::~DICOMTagsOfInterestAddHelper()
 {
   if (m_Active)
   {
-    MITK_ERROR << "DICOMTagsOfInterestAddHelper was not deactivated correctly befor its destructor was called.";
+    MITK_ERROR << "DICOMTagsOfInterestAddHelper was not deactivated correctly before its destructor was called.";
     auto context = us::GetModuleContext();
     //we cannot trust m_Context at this point anymore and have no means to validate it. So try to get the own module context
     //and to remove the listener via this context.

--- a/Modules/DICOM/src/mitkEquiDistantBlocksSorter.cpp
+++ b/Modules/DICOM/src/mitkEquiDistantBlocksSorter.cpp
@@ -292,7 +292,7 @@ mitk::EquiDistantBlocksSorter
 
   if (m_ToleratedOriginOffset > 0.5)
   {
-    MITK_WARN << "EquiDistantBlocksSorter is now accepting large errors, take care of measurements, they could appear at unprecise locations!";
+    MITK_WARN << "EquiDistantBlocksSorter is now accepting large errors, take care of measurements, they could appear at imprecise locations!";
   }
 }
 

--- a/Modules/DICOM/src/mitkThreeDnTDICOMSeriesReader.cpp
+++ b/Modules/DICOM/src/mitkThreeDnTDICOMSeriesReader.cpp
@@ -141,8 +141,8 @@ mitk::ThreeDnTDICOMSeriesReader
       }
     }
 
-    // in any case, we now now all about the first block of our list ...
-    // ... and we wither call it 3D o 3D+t
+    // in any case, we now know all about the first block of our list ...
+    // ... and we either call it 3D o 3D+t
     if (current3DnTBlockNumberOfTimeSteps > 1)
     {
       true3DnTBlocks.push_back(current3DnTBlock);

--- a/Modules/DICOM/test/mitkDICOMITKSeriesGDCMReaderBasicsTest.cpp
+++ b/Modules/DICOM/test/mitkDICOMITKSeriesGDCMReaderBasicsTest.cpp
@@ -70,8 +70,8 @@ int mitkDICOMITKSeriesGDCMReaderBasicsTest(int argc, char* argv[])
   // a sorter...
   mitk::DICOMSortCriterion::ConstPointer sorting =
     mitk::DICOMSortByTag::New( DICOMTag(0x0020, 0x0013), // instance number
-      mitk::DICOMSortByTag::New( DICOMTag(0x0020, 0x0012), // aqcuisition number
-        mitk::DICOMSortByTag::New( DICOMTag(0x0008, 0x0032), // aqcuisition time
+      mitk::DICOMSortByTag::New( DICOMTag(0x0020, 0x0012), // acquisition number
+        mitk::DICOMSortByTag::New( DICOMTag(0x0008, 0x0032), // acquisition time
           mitk::DICOMSortByTag::New( DICOMTag(0x0018, 0x1060), // trigger time
             mitk::DICOMSortByTag::New( DICOMTag(0x0008, 0x0018) // SOP instance UID (last resort, not really meaningful but decides clearly)
             ).GetPointer()

--- a/Modules/DICOMTesting/src/mitkTestDICOMLoading.cpp
+++ b/Modules/DICOMTesting/src/mitkTestDICOMLoading.cpp
@@ -256,8 +256,8 @@ mitk::TestDICOMLoading::DumpImageInformation( const Image* image )
 
       result << "  " << "TimeBounds: ";
       ///////////////////////////////////////
-      // Workarround T27883. See https://phabricator.mitk.org/T27883#219473 for more details.
-      // This workarround should be removed as soon as T28262 is solved!
+      // Workaround T27883. See https://phabricator.mitk.org/T27883#219473 for more details.
+      // This workaround should be removed as soon as T28262 is solved!
       TimeBounds timeBounds = timeGeometry->GetTimeBounds();
       auto atg = dynamic_cast<const mitk::ArbitraryTimeGeometry*>(timeGeometry);
       if (atg && atg->HasCollapsedFinalTimeStep())
@@ -267,7 +267,7 @@ mitk::TestDICOMLoading::DumpImageInformation( const Image* image )
       //Original code:
       //const TimeBounds timeBounds = timeGeometry->GetTimeBounds();
       //
-      // End of workarround for T27883
+      // End of workaround for T27883
       //////////////////////////////////////
       for (unsigned int i = 0; i < 2; ++i)
         result << timeBounds[i] << " ";


### PR DESCRIPTION
Found via `codespell -q 3 -S *.min.js -L alledges,anid,ba,childs,doubleclick,fiter,nd,parms,pres,serie,sur,toi`

Signed-off-by: luz paz <luzpaz@github.com>
