### PR TITLE
Fix 'duplicate HTML element attributes' reported by LGTM

### DIFF
--- a/Plugins/org.mitk.gui.qt.mitkworkbench.intro/resources/WelcomePresentation.html
+++ b/Plugins/org.mitk.gui.qt.mitkworkbench.intro/resources/WelcomePresentation.html
@@ -73,7 +73,7 @@
                     <br>
                     <br>
                     <br>
-                    <p class="fragment" data-fragment-index="1" class="fragment" style="text-align: center"><small>Here you can find links to further on-line tutorials and related documentation.</small></p>
+                    <p class="fragment" data-fragment-index="1" style="text-align: center"><small>Here you can find links to further on-line tutorials and related documentation.</small></p>
                     <img class="fragment current-visible" data-fragment-index="1" src="qrc:/org.mitk.gui.qt.welcomescreen.welcome.tutorial/images/welcome/MITKArrow.png" style="position: absolute; right: 38%; bottom: 33%; width: 15%; border: none; box-shadow: none; background: none; -webkit-transform: rotate(-145deg); transform: rotate(-145deg)" />
                     <br>
                 </section>


### PR DESCRIPTION
'Specifying the same attribute twice on the same HTML element is redundant and may indicate a copy-paste mistake.'

Signed-off-by: luz paz <luzpaz@github.com>
