### PR TITLE
Force a rendering update before updating the status bar.

### DIFF
--- a/Modules/Core/src/Interactions/mitkDisplayInteractor.cpp
+++ b/Modules/Core/src/Interactions/mitkDisplayInteractor.cpp
@@ -743,7 +743,9 @@ void mitk::DisplayInteractor::UpdateStatusbar(mitk::StateMachineAction *, mitk::
   // time of initiating the interaction. However, we need to update the
   // status bar with the position after changing slice. Therefore, we
   // translate the same display position with the renderer again to
-  // get the new world position.
+  // get the new world position. A rendering update is required before this.
+
+  baseRenderer->ForceImmediateUpdate();
   Point3D worldposition;
   baseRenderer->DisplayToWorld(posEvent->GetPointerPositionOnScreen(), worldposition);
 


### PR DESCRIPTION
The comment found in in DisplayInteractor was describing a
required re-calculation of the plane positions, however
rendering was not being updated and thus not able to provide
up-to-date position calculations.

This missing update was showing consequences when a user
was scrolling through slices of an image using the mouse wheel
and observing the displayed position in the status bar.
These positions would 'lag behind' when changing the scroll direction.