### PR TITLE
Do not include uic generated file in header

### DIFF
--- a/Modules/QtWidgets/include/QmitkLevelWindowWidget.h
+++ b/Modules/QtWidgets/include/QmitkLevelWindowWidget.h
@@ -14,17 +14,24 @@ found in the LICENSE file.
 #define QmitkLevelWindowWidget_h
 
 #include <MitkQtWidgetsExports.h>
-
-#include "ui_QmitkLevelWindowWidget.h"
+#include <mitkLevelWindowManager.h>
 
 #include <QWidget>
 
+// Forward declarations
+namespace Ui
+{
+  class QmitkLevelWindow;
+}
+
 /// \ingroup QmitkModule
-class MITKQTWIDGETS_EXPORT QmitkLevelWindowWidget : public QWidget, public Ui::QmitkLevelWindow
+class MITKQTWIDGETS_EXPORT QmitkLevelWindowWidget : public QWidget
 {
   Q_OBJECT
 public:
   QmitkLevelWindowWidget(QWidget *parent = nullptr, Qt::WindowFlags f = nullptr);
+  ~QmitkLevelWindowWidget() override;
+
   mitk::LevelWindowManager *GetManager();
 
 public slots:
@@ -33,5 +40,11 @@ public slots:
 protected:
   // unsigned long m_ObserverTag;
   mitk::LevelWindowManager::Pointer m_Manager;
+
+private:
+
+ //!< GUI controls of this plugin.
+  Ui::QmitkLevelWindow* ui;
+
 };
 #endif

--- a/Modules/QtWidgets/src/QmitkAbstractMultiWidget.cpp
+++ b/Modules/QtWidgets/src/QmitkAbstractMultiWidget.cpp
@@ -12,7 +12,6 @@ found in the LICENSE file.
 
 // mitk qt widgets module
 #include "QmitkAbstractMultiWidget.h"
-#include "QmitkLevelWindowWidget.h"
 #include "QmitkMultiWidgetLayoutManager.h"
 #include "QmitkRenderWindowWidget.h"
 

--- a/Modules/QtWidgets/src/QmitkLevelWindowWidget.cpp
+++ b/Modules/QtWidgets/src/QmitkLevelWindowWidget.cpp
@@ -12,14 +12,23 @@ found in the LICENSE file.
 #include "QmitkLevelWindowWidget.h"
 #include "QmitkSliderLevelWindowWidget.h"
 
-QmitkLevelWindowWidget::QmitkLevelWindowWidget(QWidget *parent, Qt::WindowFlags f) : QWidget(parent, f)
+#include "ui_QmitkLevelWindowWidget.h"
+
+
+QmitkLevelWindowWidget::QmitkLevelWindowWidget(QWidget *parent, Qt::WindowFlags f)
+  : QWidget(parent, f), ui(new Ui::QmitkLevelWindow)
 {
-  this->setupUi(this);
+  ui->setupUi(this);
 
   m_Manager = mitk::LevelWindowManager::New();
 
-  SliderLevelWindowWidget->SetLevelWindowManager(m_Manager.GetPointer());
-  LineEditLevelWindowWidget->SetLevelWindowManager(m_Manager.GetPointer());
+  ui->SliderLevelWindowWidget->SetLevelWindowManager(m_Manager.GetPointer());
+  ui->LineEditLevelWindowWidget->SetLevelWindowManager(m_Manager.GetPointer());
+}
+
+QmitkLevelWindowWidget::~QmitkLevelWindowWidget()
+{
+     delete ui;
 }
 
 void QmitkLevelWindowWidget::SetDataStorage(mitk::DataStorage *ds)


### PR DESCRIPTION
QmitkLevelWindowWidget.h included ui_QmitkLevelWindowWidget.h. This is a file generated by QT's uic. And it is not right to include it in the header. An application that includes QmitkLevelWindowWidget.h fails to compile. A correct way is to do forward declaration in the header and include the generated header in the corresponding cpp file. Please see the commit for more details; it is a standard way to use uic generated headers, and is already used in many mitk headers already.

Signed-off-by: Sukhraj Singh <sukhraj.singh01@stryker.com>