### PR TITLE
Workbench crash on simple tree model update.

### DIFF
--- a/Modules/QtWidgets/src/QmitkDataStorageSimpleTreeModel.cpp
+++ b/Modules/QtWidgets/src/QmitkDataStorageSimpleTreeModel.cpp
@@ -199,6 +199,10 @@ QVariant QmitkDataStorageSimpleTreeModel::data(const QModelIndex &index, int rol
 
   mitk::DataNode *dataNode = treeItem->GetDataNode();
 
+  // No need to access dataNode if that is pointing to nullptr, it will always give segfault
+  if (!dataNode)
+    return QModelIndex();
+
   QString nodeName = QString::fromStdString(dataNode->GetName());
   if (nodeName.isEmpty())
   {


### PR DESCRIPTION
    Reproduction steps followed:
    1. Enable the DataStorageViewer Test plugin.
    2. Load a data node and create a child node.
    3. For child node create a polygon model.
    4. Remove parent node then remove child node.
    5. Try to remove the last remaining polygon model, Application crashing at this point.

    Since after removing the last remaining polygon model, QmitkDataStorageSimpleTreeModel::data(const QModelIndex &index, int role) const
    gets called and this function is used and gets called after any kind of updation in tree model and after the last node is removed there
    is not any reason to access the dataNode pointer which points to dataNode that are already removed and now it is pointing to null, so
    logically it is better to check an if condition that
    if (!dataNode)
      return QModelIndex()
    It will avoid segfault due to which application was crashing.