### PR TITLE
T29013 LabelSetImage unnecessarily have a color property.

### DIFF
--- a/Modules/QtWidgets/src/QmitkPropertyItemModel.cpp
+++ b/Modules/QtWidgets/src/QmitkPropertyItemModel.cpp
@@ -149,7 +149,11 @@ QVariant QmitkPropertyItemModel::data(const QModelIndex &index, int role) const
       }
       else if (auto colorProperty = dynamic_cast<mitk::ColorProperty *>(property))
       {
-        return MitkToQt(colorProperty->GetValue());
+	      //T29013 : Making color property non editable.
+	      if (m_ClassName != "LabelSetImage")
+	      {
+		      return MitkToQt(colorProperty->GetValue());
+	      }
       }
     }
     else if (role == mitk::PropertyRole)


### PR DESCRIPTION
Since we are maintaining a single propertyList for all kind of images(regular medical image, LabelSetimage), we are not able to delete it. So as part of fix to this issue I have disable color property for lablesetImage. so it will not be selectable in this case. If you still want to remove this property completely please put your suggesion.