### PR TITLE
Fix typos in various directories

### DIFF
--- a/CMake/GetPrerequisites.cmake
+++ b/CMake/GetPrerequisites.cmake
@@ -62,7 +62,7 @@ message("Using MITK version of GetPrerequisites.cmake")
 # exclude "system" prerequisites.  If <recurse> is set to 1 all
 # prerequisites will be found recursively, if set to 0 only direct
 # prerequisites are listed.  <exepath> is the path to the top level
-# executable used for @executable_path replacment on the Mac.  <dirs> is
+# executable used for @executable_path replacement on the Mac.  <dirs> is
 # a list of paths where libraries might be found: these paths are
 # searched first when a target without any path info is given.  Then
 # standard system locations are also searched: PATH, Framework
@@ -80,7 +80,7 @@ message("Using MITK version of GetPrerequisites.cmake")
 # direct prerequisites are listed.  <exclude_system> must be 0 or 1
 # indicating whether to include or exclude "system" prerequisites.  With
 # <verbose> set to 0 only the full path names of the prerequisites are
-# printed, set to 1 extra informatin will be displayed.
+# printed, set to 1 extra information will be displayed.
 #
 # ::
 #

--- a/CMake/NSIS.template.in
+++ b/CMake/NSIS.template.in
@@ -913,7 +913,7 @@ Section "Uninstall"
 @CPACK_NSIS_DELETE_ICONS@
 @CPACK_NSIS_DELETE_ICONS_EXTRA@
 
-  ;Delete empty start menu parent diretories
+  ;Delete empty start menu parent directories
   StrCpy $MUI_TEMP "$SMPROGRAMS\$MUI_TEMP"
 
   startMenuDeleteLoop:
@@ -932,7 +932,7 @@ Section "Uninstall"
   Delete "$SMPROGRAMS\$MUI_TEMP\Uninstall.lnk"
 @CPACK_NSIS_DELETE_ICONS_EXTRA@
 
-  ;Delete empty start menu parent diretories
+  ;Delete empty start menu parent directories
   StrCpy $MUI_TEMP "$SMPROGRAMS\$MUI_TEMP"
 
   secondStartMenuDeleteLoop:

--- a/CMake/mitkFunctionCMakeDoxygenFilterCompile.cmake
+++ b/CMake/mitkFunctionCMakeDoxygenFilterCompile.cmake
@@ -79,7 +79,7 @@ function(mitkFunctionCMakeDoxygenFilterCompile)
              )
 
   if(NOT result_var)
-    message(FATAL_ERROR "error: Faild to compile ${cmake_doxygen_filter_src} (result: ${result_var})\n${compile_output}")
+    message(FATAL_ERROR "error: Failed to compile ${cmake_doxygen_filter_src} (result: ${result_var})\n${compile_output}")
   endif()
 
   set(CMakeDoxygenFilter_EXECUTABLE "${copy_file}" PARENT_SCOPE)

--- a/CMake/mitkFunctionCheckCompilerFlags.cmake
+++ b/CMake/mitkFunctionCheckCompilerFlags.cmake
@@ -83,7 +83,7 @@ function(mitkFunctionCheckCAndCXXCompilerFlags FLAG_TO_TEST C_RESULT_VAR CXX_RES
   # the same variable name skip the compilation step.
   # For that same reason, the mitkFunctionCheckCompilerFlags2 function appends a unique suffix to
   # the HAS_CXX_FLAG and HAS_C_FLAG variable. This suffix is created using a 'clean version' of the
-  # flag to test. The value of HAS_C(XX)_FLAG_${suffix} additonally needs to be a valid
+  # flag to test. The value of HAS_C(XX)_FLAG_${suffix} additionally needs to be a valid
   # pre-processor token because CHECK_CXX_COMPILER_FLAG adds it as a definition to the compiler
   # arguments. An invalid token triggers compiler warnings, which in case of the "-Werror" flag
   # leads to false-negative checks.

--- a/CMake/mitkFunctionCleanExternalProject.cmake
+++ b/CMake/mitkFunctionCleanExternalProject.cmake
@@ -6,7 +6,7 @@
     cleaning of previous build artifacts to prevent MITK from referring to
     mixed versions of the same external project.
 
-    This function tries to mimic the manual cleaning of old build articafts
+    This function tries to mimic the manual cleaning of old build artifacts
     by removing the source, build, and stamp directory of the external project
     as well as all files in the external project's install manifest, if found.
 

--- a/CMake/mitkFunctionCreateModule.cmake
+++ b/CMake/mitkFunctionCreateModule.cmake
@@ -291,7 +291,7 @@ function(mitk_create_module)
     endif()
 
     if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/src")
-      # Preprend the "src" directory to the cpp file list
+      # Prepend the "src" directory to the cpp file list
       set(_cpp_files ${CPP_FILES})
       set(CPP_FILES )
       foreach(_cpp_file ${_cpp_files})

--- a/CMake/mitkFunctionOrganizeSources.cmake
+++ b/CMake/mitkFunctionOrganizeSources.cmake
@@ -10,7 +10,7 @@ function(mitkFunctionOrganizeSources)
   # are later accessed by the keyword foreach(MYFILE ${ARGV})
 
   # output: after calling the macro, files that were found
-  # correspondigly to the given files are stored in the
+  # correspondingly to the given files are stored in the
   # variable:
   # ${CORRESPONDING_H_FILES}
   # ${CORRESPONDING_TXX_FILES}

--- a/CMake/mitkFunctionWhitelists.cmake
+++ b/CMake/mitkFunctionWhitelists.cmake
@@ -51,7 +51,7 @@ endfunction()
 #
 # mitkFunctionFindWhitelists
 #
-#! Adds all whitelists found in specfied whitelist paths to the advanced cache
+#! Adds all whitelists found in specified whitelist paths to the advanced cache
 #! variable <prefix>_WHITELIST as enumeration entries.
 #!
 #! USAGE:

--- a/CMake/mitkMacroInstallHelperApp.cmake
+++ b/CMake/mitkMacroInstallHelperApp.cmake
@@ -1,4 +1,4 @@
-#! MITK specific cross plattform install macro
+#! MITK specific cross platform install macro
 #!
 #! Usage: MITK_INSTALL_HELPER_APP(target1 [target2] ....)
 #!

--- a/CMake/mitkMacroInstallTargets.cmake
+++ b/CMake/mitkMacroInstallTargets.cmake
@@ -1,5 +1,5 @@
 #
-# MITK specific cross plattform install macro
+# MITK specific cross platform install macro
 #
 # Usage: MITK_INSTALL_TARGETS(target1 [target2] ....)
 #

--- a/CMake/mitkMacroMultiplexPicType.cmake
+++ b/CMake/mitkMacroMultiplexPicType.cmake
@@ -4,7 +4,7 @@
 # instantiation
 #
 # Param "file" should be named like mitkMyAlgo-TYPE.cpp
-# in the file, every occurence of @TYPE@ is replaced by the
+# in the file, every occurrence of @TYPE@ is replaced by the
 # datatype. For each datatype, a new file mitkMyAlgo-datatype.cpp
 # is generated and added to CPP_FILES_GENERATED.
 #

--- a/CMake/mitkSwigAddLibraryDependencies.cmake
+++ b/CMake/mitkSwigAddLibraryDependencies.cmake
@@ -20,7 +20,7 @@ function(mitkSwigAddLibraryDependencies swig_module library_names)
         get_property(LIBRARY_INCLUDES
                      TARGET ${library_name}
                      PROPERTY INTERFACE_INCLUDE_DIRECTORIES)
-        # Checking each given librarie to include all includes from this library.
+        # Checking each given library to include all includes from this library.
 
     endforeach()
 

--- a/CMake/mitkTargetLinkLibrariesWithDynamicLookup.cmake
+++ b/CMake/mitkTargetLinkLibrariesWithDynamicLookup.cmake
@@ -362,7 +362,7 @@ function(_test_weak_link_project
       file(APPEND "${test_project_src_dir}/main.c" "
         goto done;
         error:
-          fprintf(stderr, \"Error occured:\\n    %s\\n\", dlerror());
+          fprintf(stderr, \"Error occurred:\\n    %s\\n\", dlerror());
           result = 1;
 
         done:

--- a/CMake/mitkTestDriverFiles.cmake.in
+++ b/CMake/mitkTestDriverFiles.cmake.in
@@ -35,7 +35,7 @@ create_test_sourcelist(_test_cpp_files ${MODULE_NAME}_main.cpp
 list(APPEND CPP_FILES ${_test_cpp_files})
 
 # Some old CMake scripts use TEST_CPP_FILES in their files.cmake
-# file of the test driver to add source fiels to the executable
+# file of the test driver to add source files to the executable
 # (they should just use CPP_FILES like in any other files.cmake
 # file instead).
 if(TEST_CPP_FILES)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -848,7 +848,7 @@ foreach(ep ${MITK_EXTERNAL_PROJECTS})
       string(TOUPPER "${_package}" _package_uc)
       if(NOT (${_package}_FOUND OR ${_package_uc}_FOUND))
         if(DEFINED _temp_EP_${_package}_dir)
-            set(${_package}_DIR ${_temp_EP_${_package}_dir} CACHE PATH "externaly set dir of the package ${_package}" FORCE)
+            set(${_package}_DIR ${_temp_EP_${_package}_dir} CACHE PATH "externally set dir of the package ${_package}" FORCE)
         endif(DEFINED _temp_EP_${_package}_dir)
 
         find_package(${_package} REQUIRED)
@@ -876,7 +876,7 @@ endif()
 if(MITK_USE_DCMQI)
   # Due to the preferred CONFIG mode in find_package calls above,
   # the DCMQIConfig.cmake file is read, which does not provide useful
-  # package information. We explictly need MODULE mode to find DCMQI.
+  # package information. We explicitly need MODULE mode to find DCMQI.
     # Help our FindDCMQI.cmake script find our super-build DCMQI
   set(DCMQI_DIR ${MITK_EXTERNAL_PROJECT_PREFIX})
   find_package(DCMQI REQUIRED)

--- a/Documentation/CMakeDoxygenFilter.cpp
+++ b/Documentation/CMakeDoxygenFilter.cpp
@@ -25,7 +25,7 @@
 #include <assert.h>
 
 //--------------------------------------
-// Utilitiy classes and functions
+// Utility classes and functions
 //--------------------------------------
 
 struct ci_char_traits : public std::char_traits<char>

--- a/Documentation/Doxygen/2-UserManual/MITKPluginManualsList.dox
+++ b/Documentation/Doxygen/2-UserManual/MITKPluginManualsList.dox
@@ -1,7 +1,7 @@
 /**
 \page PluginListPage MITK Plugin Manuals
 
-The plugins and bundles provide much of the extended functionality of MITK. Each encapsulates a solution to a problem and associated features. This way one can easily assemble the necessary capabilites for a workflow without adding a lot of bloat, by combining plugins as needed.
+The plugins and bundles provide much of the extended functionality of MITK. Each encapsulates a solution to a problem and associated features. This way one can easily assemble the necessary capabilities for a workflow without adding a lot of bloat, by combining plugins as needed.
 
 <ul>
   <li> \subpage org_mitk_views_basicimageprocessing </li>

--- a/Documentation/Doxygen/3-DeveloperManual/Application/BlueBerry/BlueBerryExtensionPointsIntro.dox
+++ b/Documentation/Doxygen/3-DeveloperManual/Application/BlueBerry/BlueBerryExtensionPointsIntro.dox
@@ -2,7 +2,7 @@
 
 \page BlueBerryExampleExtensionPoint Extension Points
 
-\brief A minimal applictaion that definines an extension point and collects extensions.
+\brief A minimal application that defines an extension point and collects extensions.
 
 -# \subpage IntroductionExtensionPoints "Introduction"
 -# \subpage ExtensionPointDefinition "Extension Point Definition"

--- a/Documentation/Doxygen/3-DeveloperManual/Application/BlueBerry/BlueBerryIntro.dox
+++ b/Documentation/Doxygen/3-DeveloperManual/Application/BlueBerry/BlueBerryIntro.dox
@@ -19,7 +19,7 @@ The BlueBerry developer reference is available here:
 
 \page BlueBerryWorkbench The Workbench: What are Views, Editors, Perspectives?
 
-BlueBerry makes use of the Eclipse UI guidlines which state some concepts on how to build up a GUI. The different objects of the platform UI shall be described here:
+BlueBerry makes use of the Eclipse UI guidelines which state some concepts on how to build up a GUI. The different objects of the platform UI shall be described here:
 
 \section Workbench Workbench
 \li root object of the platform UI

--- a/Documentation/Doxygen/3-DeveloperManual/Application/BlueBerryExtensionPointReference.dox
+++ b/Documentation/Doxygen/3-DeveloperManual/Application/BlueBerryExtensionPointReference.dox
@@ -95,12 +95,12 @@ Otherwise \c EvaluationResult.FALSE is returned.
 \endcode
 
 This element is used to evaluate the property state of the object in focus.
-The set of testable properties can be extended using the propery tester extension point.
+The set of testable properties can be extended using the property tester extension point.
 The test expression returns \c EvaluationResult.NOT_LOADED if the property tester doing the actual testing isn't loaded yet and the attribute \c forcePluginActivation is set to \c false.
 If \c forcePluginActivation is set to \c true and the evaluation context used to evaluate this expression support plug-in activation then evaluating the property will result in activating the plug-in defining the tester.
 
 - <tt>property</tt>: The name of an object's property to test.
-- <tt>args</tt>: Additional arguments passed to the property tester. Multiple arguments are seperated by commas. Each individual argument is converted into a Java base type using the same rules as defined for the value attribute of the test expression.
+- <tt>args</tt>: Additional arguments passed to the property tester. Multiple arguments are separated by commas. Each individual argument is converted into a Java base type using the same rules as defined for the value attribute of the test expression.
 - <tt>value</tt>: The expected value of the property. Can be omitted if the property is a boolean property. The test expression is supposed to return \c EvaluationResult.TRUE if the property matches the value and \c EvaluationResult.FALSE otherwise. The value attribute is converted into a Java base type using the following rules:
  - The string \c "true" is converted into \c Boolean.TRUE .
  - The string \c "false" is converted into \c Boolean.FALSE .
@@ -173,7 +173,7 @@ If the variable can not be resolved then the expression will throw an \c Express
 The children of a with expression are combined using the and operator.
 
 - <tt>variable</tt>: The name of the variable to be resolved. This variable is then used as the object in focus for child element evaluation. It is up to the evaluator of an extension point to provide a corresponding variable resolver (see berry::IVariableResolver) through the evaluation context passed to the root expression element when evaluating the expression.
-- <tt>args</tt>: Additional arguments passed to the variable resolver. Multiple arguments are seperated by commas. Each individual argument is converted into a Java base type using the same rules as defined for the value attribute of the test expression.
+- <tt>args</tt>: Additional arguments passed to the variable resolver. Multiple arguments are separated by commas. Each individual argument is converted into a Java base type using the same rules as defined for the value attribute of the test expression.
 
 \code{.unparsed}
 <!ELEMENT adapt (not , and , or , instanceof , test , systemTest , equals , count , with , resolve , adapt , iterate , reference)*>
@@ -299,12 +299,12 @@ Otherwise \c EvaluationResult.FALSE is returned.
 \endcode
 
 This element is used to evaluate the property state of the object in focus.
-The set of testable properties can be extended using the propery tester extension point.
+The set of testable properties can be extended using the property tester extension point.
 The test expression returns \c EvaluationResult.NOT_LOADED if the property tester doing the actual testing isn't loaded yet and the attribute \c forcePluginActivation is set to false.
 If \c forcePluginActivation is set to \c true and the evaluation context used to evaluate this expression support plug-in activation then evaluating the property will result in activating the plug-in defining the tester.
 
 - <tt>property</tt>: The name of an object's property to test.
-- <tt>args</tt>: Additional arguments passed to the property tester. Multiple arguments are seperated by commas. Each individual argument is converted into a Java base type using the same rules as defined for the value attribute of the test expression.
+- <tt>args</tt>: Additional arguments passed to the property tester. Multiple arguments are separated by commas. Each individual argument is converted into a Java base type using the same rules as defined for the value attribute of the test expression.
 - <tt>value</tt>: The expected value of the property. Can be omitted if the property is a boolean property. The test expression is supposed to return EvaluationResult.TRUE if the property matches the value and EvaluationResult.FALSE otherwise. The value attribute is converted into a Java base type using the following rules:
  - The string "true" is converted into \c Boolean.TRUE
  - The string "false" is converted into \c Boolean.FALSE
@@ -377,7 +377,7 @@ If the variable can not be resolved then the expression will throw an \c Express
 The children of a with expression are combined using the and operator.
 
 - <tt>variable</tt>: The name of the variable to be resolved. This variable is then used as the object in focus for child element evaluation. It is up to the evaluator of an extension point to provide a corresponding variable resolver (see berry::IVariableResolver) through the evaluation context passed to the root expression element when evaluating the expression.
-- <tt>args</tt>: Additional arguments passed to the variable resolver. Multiple arguments are seperated by commas. Each individual argument is converted into a Java base type using the same rules as defined for the value attribute of the test expression.
+- <tt>args</tt>: Additional arguments passed to the variable resolver. Multiple arguments are separated by commas. Each individual argument is converted into a Java base type using the same rules as defined for the value attribute of the test expression.
 
 \code{.unparsed}
 <!ELEMENT adapt (not , and , or , instanceof , test , systemTest , equals , count , with , resolve , adapt , iterate , reference)*>
@@ -1130,7 +1130,7 @@ Contribute services to the workbench.
   factoryClass CDATA #REQUIRED>
 \endcode
 
-Match a service interface to a factory that can supply a hierachical implementation of that service.
+Match a service interface to a factory that can supply a hierarchical implementation of that service.
 
 - <tt>factoryClass</tt>: The factory that extends \c AbstractServiceFactory and can create the implementation for the \c serviceClass.
 
@@ -1310,12 +1310,12 @@ An optional subelement whose body should contain text providing a short descript
 A sticky view is a view that will appear by default across all perspectives in a window once it is opened.
 Its initial placement is governemed by the location attribute, but nothing prevents it from being moved or closed by the user.
 Use of this element will only cause a placeholder for the view to be created, it will not show the view.
-Please note that usage of this element should be done with great care and should only be applied to views that truely have a need to live across perspectives.
+Please note that usage of this element should be done with great care and should only be applied to views that truly have a need to live across perspectives.
 
 - <tt>id</tt>: the id of the view to be made sticky.
 - <tt>location</tt>: optional attribute that specifies the location of the sticky view relative to the editor area. If absent, the view will be docked to the right of the editor area.
-- <tt>closeable</tt>: optional attribute that specifies wether the view should be closeable. If absent it will be closeable.
-- <tt>moveable</tt>: optional attribute that specifies wether the view should be moveable. If absent it will be moveable.
+- <tt>closeable</tt>: optional attribute that specifies whether the view should be closeable. If absent it will be closeable.
+- <tt>moveable</tt>: optional attribute that specifies whether the view should be moveable. If absent it will be moveable.
 
 \subsection BlueBerryExtPointsIndex_Workbench_Views_Examples Examples
 

--- a/Documentation/Doxygen/3-DeveloperManual/Concepts/Annotation.dox
+++ b/Documentation/Doxygen/3-DeveloperManual/Concepts/Annotation.dox
@@ -24,14 +24,14 @@ It also manages the respective Layouters which are used to manage the placement 
 
 The mitk::Annotation is an abstract class that can manage property lists like the mitk::DataNode and provides the interfaces to the methods
 AddToBaseRenderer, AddToRenderer, RemoveFromBaseRenderer RemoveFromRenderer and Update. The subclasses of the mitk::Annotation have to implement these methods
-in order to provide the functionallity of an Annotation. There are already a few implementations of mitk::Annotation which are using VTK as a rendering
+in order to provide the functionality of an Annotation. There are already a few implementations of mitk::Annotation which are using VTK as a rendering
 framework to display the Annotations. In order to show an Annotation, it has to be registered as a MicroService.
 
 \subsection AnnotationPage_AnnotationRendererSubsection AbstractAnnotationRenderer
 
 The AbstractAnnotationRenderer is the base class for all types of AnnotationRenderers, which are used for the management of multiple annotations in a specific BaseRenderer.
-For each BaseRenderer, an AnnotationRenderer is registerered as a MicroService, using the type and the renderer name as a unique identifier. This way it is possible to keep the Annotations for a specific BaseRenderer
-even if this renderer is temporarilly not existent (e.g. when a RenderWindow was closed).
+For each BaseRenderer, an AnnotationRenderer is registered as a MicroService, using the type and the renderer name as a unique identifier. This way it is possible to keep the Annotations for a specific BaseRenderer
+even if this renderer is temporarily not existent (e.g. when a RenderWindow was closed).
 
 Implementations of the AbstractAnnotationRenderer are using the us::ServiceTracker in order to manage all registered Annotations and to listen to the events which are thrown if a new Annotation is registered,
 if an Annotation was unregistered or if it was modified.

--- a/Documentation/Doxygen/3-DeveloperManual/Concepts/BasicDataTypes.dox
+++ b/Documentation/Doxygen/3-DeveloperManual/Concepts/BasicDataTypes.dox
@@ -14,7 +14,7 @@ mitkVector.h has been split up into several, more atomic files, namely:
 -# mitkNumericConstants.h : contains basic constants like mitk::ScalarType or mitk::eps
 -# mitkArray.h : copy itk::FixedArrays (like itk::Point and itk::Vector) from and to types which implement the [] operator (array-types), like e.g. Plain Old Datatypes (POD) or the opencv vector
 -# mitkPoint.h : the mitk::Point class. This is basically the itk::Point with the added ToArray and Fill members to conveniently copy from and to array-types. In MITK, a point is considered a fixed geometric location and thus cannot be summed or multiplied.
--# mitkVector.h : the mitk::Vector class. This is an itk::Vector, but with the possiblity to implicitly convert to vnl_vector and vnl_vector_fixed. In MITK, vectors denote directions and can be summed or multiplied with scalars.
+-# mitkVector.h : the mitk::Vector class. This is an itk::Vector, but with the possibility to implicitly convert to vnl_vector and vnl_vector_fixed. In MITK, vectors denote directions and can be summed or multiplied with scalars.
 -# mitkMatrix.h : the mitk::Matrix class. This is an itk::Matrix with the added ToArray and Fill members to conveniently copy from and to array-types.
 -# mitkQuaternion.h : a typedef to vnl_quaternion.
 -# mitkAffineTransform3D.h : a typedef to itk::ScalableAffineTransform<ScalarType, 3>

--- a/Documentation/Doxygen/3-DeveloperManual/Concepts/DICOMTesting.dox
+++ b/Documentation/Doxygen/3-DeveloperManual/Concepts/DICOMTesting.dox
@@ -10,7 +10,7 @@ DICOMITKSeriesGDCMReader (formerly: DicomSeriesReader) brings DICOM and MITK as 
 into mitk::Images, optionally grouping slices to 3D+t images.
 
 Since there are so many possible sources for mistakes with any change to this loading process, testing the many
-assumptions implemented in DICOMITKSeriesGDCMReader is worthwhile. This document describes what and how theses kind of tests are implemented.
+assumptions implemented in DICOMITKSeriesGDCMReader is worthwhile. This document describes what and how these kind of tests are implemented.
 
 \section DICOMTesting_problem Problem description
 
@@ -19,7 +19,7 @@ in the way that DICOM and MITK represent images:
 
  - DICOM images
    + are mostly stored as one slice per file
-   + do not describe how they can be arraged into image stacks with orthogonal axis
+   + do not describe how they can be arranged into image stacks with orthogonal axis
    + sometimes they cannot be arranged in image stacks as described above (e.g. tilted gantry)
  - mitk::Image (at least its mature areas)
    + represents image stacks with orthogonal axis (nothing like a tilted gantry)
@@ -118,9 +118,9 @@ From test set \b TinyCTAbdomen (see description.txt in this directory for detail
  - 3D_and_T : load a small set of slices with multiple time-steps
  - diff_orientation : load a set of files containing two differently oriented image blocks; at least two images (110,111) have minor errors in small decimal digits
  - diff_orientation_gaps : load a set of files containing two differently oriented image blocks, each missing slices, so blocks must be split
- - diff_spacing : load a set of files containint two set of slices with different spacings
+ - diff_spacing : load a set of files containing two set of slices with different spacings
  - gap : load slices that cannot form a single 3D block, because single slices are missing
- - gaps : slices missing in differnt locations, so multiple splits needed
+ - gaps : slices missing in different locations, so multiple splits needed
  - unsorted_gaps : as before, just file names are unsorted
  - single_negative_spacing : from reported bug related to single MR images with misleading spacing information
  - tilted_gantry : slice origins do not align along first slice normal (happens with tilted gantries)

--- a/Documentation/Doxygen/3-DeveloperManual/Concepts/DataInteraction.dox
+++ b/Documentation/Doxygen/3-DeveloperManual/Concepts/DataInteraction.dox
@@ -20,7 +20,7 @@ See the \ref DataInteractionTechnicalPage page for a more technical explanation.
 Consult \ref HowToUseDataInteractor for usage information.\n
 See \ref SectionImplementationDataInteractor for an example on how to implement a new mitk::DataInteractor \n
 for information about how to create new events refer to ImplementNewEventsPage.\n
-The documentation of the depricated former concept can be found at \ref InteractionPage.
+The documentation of the deprecated former concept can be found at \ref InteractionPage.
 \n
 For a list of changes with respect to the previous interaction concept please refer to the \ref InteractionMigration
 
@@ -70,7 +70,7 @@ digraph linker_deps {
 \enddot
 
 \subsection DataInteractionPage_DataInteractorsSection DataInteractors
-DataInteractors are specialized mitk::InteractionEventHandler which handle events for one spefific DataNode. They are implemented following a concept called state machines
+DataInteractors are specialized mitk::InteractionEventHandler which handle events for one specific DataNode. They are implemented following a concept called state machines
 (see e.g. <a href="https://en.wikipedia.org/wiki/Mealy_machine"> Wikipedia </a>).
 
 \subsubsection DataInteractionPage_StateMachinesSection StateMachines

--- a/Documentation/Doxygen/3-DeveloperManual/Concepts/Exceptions.dox
+++ b/Documentation/Doxygen/3-DeveloperManual/Concepts/Exceptions.dox
@@ -34,7 +34,7 @@ class myExampleClass
  
   /**  Documentation
    *  @brief This method does [...]
-   *  @throws mitk::Exception This exception is thrown, when the following error occures: [...]
+   *  @throws mitk::Exception This exception is thrown, when the following error occurs: [...]
    */
 
   void MyExampleMethod()
@@ -42,7 +42,7 @@ class myExampleClass
     //here comes your code
     
     //here happens an exception
-    mitkThrow() << "An exception occured because [...], method can't continue.";
+    mitkThrow() << "An exception occurred because [...], method can't continue.";
     }
   }
 \endverbatim
@@ -66,11 +66,11 @@ catch (const mitk::Exception& e)
   }
 \endverbatim
 
-Please do not use "catch (...)" because normally your class can't garantee to handle all exceptions in a proper way without differentiating them.
+Please do not use "catch (...)" because normally your class can't guarantee to handle all exceptions in a proper way without differentiating them.
 
 \section SpecializedExceptionHandling Defining and Using more Specialized Exceptions
 
-The basic MITK exception concept was kept very simple and should suffice in many cases. But you can also use more specialized exceptions, if needed. Nevertheless all MITK exceptions should be subclasses of mitk::exception. You can define your own exception classes by simply implementing new classes which derive from mitk::exception. Thus, you can catch your exception seperately when needed. The mitkExceptionClassMacro helps to keep implementing new exception classes as simple as possible, like shown in the following code example.
+The basic MITK exception concept was kept very simple and should suffice in many cases. But you can also use more specialized exceptions, if needed. Nevertheless all MITK exceptions should be subclasses of mitk::exception. You can define your own exception classes by simply implementing new classes which derive from mitk::exception. Thus, you can catch your exception separately when needed. The mitkExceptionClassMacro helps to keep implementing new exception classes as simple as possible, like shown in the following code example.
 
 \verbatim
 #include <mitkCommon.h>
@@ -82,7 +82,7 @@ class mitk::MySpecializedException : public mitk::Exception
   };
 \endverbatim
 
-To throw your specialized exception you should use the corresponing macro, which is shown in the next code snippet.
+To throw your specialized exception you should use the corresponding macro, which is shown in the next code snippet.
 
 \verbatim
 mitkThrowException(mitk::MySpecializedException) << "this is error info"; 

--- a/Documentation/Doxygen/3-DeveloperManual/Concepts/GeometryOverview.dox
+++ b/Documentation/Doxygen/3-DeveloperManual/Concepts/GeometryOverview.dox
@@ -14,7 +14,7 @@ To use the geometry classes in the right way you have to understand the three di
 
 \subsection GeometryOverviewPage_WorldCoord
 
-- World coordinates are describing the actual spacial position of all MITK objects regarding a global coordinate system, normally specified by the imaging modality
+- World coordinates are describing the actual spatial position of all MITK objects regarding a global coordinate system, normally specified by the imaging modality
 - World coordinates are represented by  mitk::Point3D objects.
 - The geometry defines the offset, orientation, and scale of the considered data objects in reference to the world coordinate systems.
 - World coordinates are always measured in mm
@@ -32,7 +32,7 @@ To use the geometry classes in the right way you have to understand the three di
 
 \subsubsection GeometryOverviewPage_CenterCoord_ContIdx Continuous index coordinates
 
-- Dividing world coordinates through the pixel spacing and simultanously taking the offset into account leads to continuous index coordinates inside your dataobject. So continuous coordinates can be float values!
+- Dividing world coordinates through the pixel spacing and simultaneously taking the offset into account leads to continuous index coordinates inside your dataobject. So continuous coordinates can be float values!
 - Continuous index coordinates are represented by  mitk::Point3D objects.
 - They can be obtained by calling mitk::BaseGeometry::WorldToIndex(), where &pt_mm is a point in worldcoordinates.\n
 
@@ -46,21 +46,21 @@ To use the geometry classes in the right way you have to understand the three di
 
 \section GeometryOverviewPage_PointsAndVector Difference between Points and Vectors
 
-Like ITK, MITK differenciate between points and vectors.
+Like ITK, MITK differentiate between points and vectors.
 A point defines a position in a coordinate system while a vector is the distance between two points.
 Therefore points and vectors behave different if a coordinate transformation is applied.
-An offest in a coordinate transformation will affect a transformed point but not a vector.
+An offset in a coordinate transformation will affect a transformed point but not a vector.
 
 An Example:
 
-If two systems are given, which differ by a offset of (1,0,0). The point A(2,2,2) in system one will correspont to point A'(3,2,2) in the second system.
+If two systems are given, which differ by a offset of (1,0,0). The point A(2,2,2) in system one will correspond to point A'(3,2,2) in the second system.
 But a vector a(2,2,2) will correspond to the vector a'(2,2,2).
 
 \section GeometryOverviewPage_Concept The Geometry Concept
 
 As the superclass of all MITK geometries mitk::BaseGeometry holds:
 
-- a spacial bounding box which is axes-parallel in index coordinates (often discrete indices of pixels), to be accessed by BaseGeometry::GetBoundingBox()
+- a spatial bounding box which is axes-parallel in index coordinates (often discrete indices of pixels), to be accessed by BaseGeometry::GetBoundingBox()
 - a time related bounding box which holds the temporal validity of the considered data object in milliseconds (start and end time), to be accessed by BaseGeometry::GetTimeBounds(). The default for 3D geometries is minus infinity to plus infinity, meaning the object is always displayed independent of displayed time in MITK.
 - position information in form of a Euclidean transform in respect to world coordinates (i.e. a linear transformation matrix and offset) to convert (discrete or continuous) index coordinates to world coordinates and vice versa, to be accessed by mitk::BaseGeometry::GetIndexToWorldTransform(). See also: \ref GeometryOverviewPage_Introduction "Introduction to Geometries"
 - Many other properties (e.g. origin, extent, ...) which can be found in the mitk::BaseGeometry "class documentation"
@@ -71,7 +71,7 @@ This mitk::TimeGeometry holds one or more mitk::BaseGeometry objects which descr
 There is the possibility of using different implementations of the abstract mitk::TimeGeometry class which may differ in how the time steps are saved and the times are calculated.
 
 There are two ways to represent a time, either by a mitk::TimePointType or a mitk::TimeStepType.
-The first is similar to the continous index coordinates and defines a Time Point in milliseconds from timepoint zero.
+The first is similar to the continuous index coordinates and defines a Time Point in milliseconds from timepoint zero.
 The second type is similar to index coordinates.
 These are discrete values which specify the number of the current time step going from 0 to GetNumberOfTimeSteps().
 The conversion between a time point and a time step is done by calling the method mitk::TimeGeometry::TimeStepToTimePoint() or mitk::TimeGeometry::TimePointToTimeStep().
@@ -145,7 +145,7 @@ If you experience displaced contours, figures or other stuff, it is an indicator
 An image has a mitk::TimeGeometry, which contains one or more mitk::SlicedGeometry3D instances (one for each time step), all of which contain one or more instances of (sub-classes of) mitk::PlaneGeometry.
 
 As a reminder: Geometry instances referring to images need a slightly different definition of corners, see mitk::BaseGeometry::SetImageGeometry.
-This is usualy automatically called by Image.
+This is usually automatically called by Image.
 
 \section GeometryOverviewPage_Connection Connection between MITK, ITK and VTK Geometries
 

--- a/Documentation/Doxygen/3-DeveloperManual/Concepts/Interaction.dox
+++ b/Documentation/Doxygen/3-DeveloperManual/Concepts/Interaction.dox
@@ -46,7 +46,7 @@ Event 1 is sent to the state machine. This leads the current state from state 1 
 
 \subsection InteractionPage_XMLDefinitionStatemachine Definition of a State machine
 Due to the separation of the definition of an interaction sequence and its implementation, the definition has to be archived somewhere, where the application can reach it during startup and build up all the objects (states, transitions and actions) that represent the sequence of a special interaction.
-In MITK, these informations are defined in an XML-file (i.e. DisplayInteraction.xml or BoundingShapeInteraction.xml)
+In MITK, this information is defined in an XML-file (i.e. DisplayInteraction.xml or BoundingShapeInteraction.xml)
 \note Please note that since this is a resource which is compiled into the executable, changes you make to this file will only be reflected in application behavior after you recompile your code.
 
 The structure is the following (from \ref InteractionPage_ExampleA) :
@@ -73,7 +73,7 @@ The structure is the following (from \ref InteractionPage_ExampleA) :
 \endcode
 
 The identification numbers (ID) inside a state machine have to be unique. Each state machine has to have one state, that is defined as the start-state of that state machine. This means, initially, the current state of the state machine is the start-state. 
-The Event-Ids seen above are also defined in the statemachine.xml file. They specify a unique number for a combination of input-conditions (key, mouse and so on). See \ref InteractionPage_InteractionEvents for further informations.
+The Event-Ids seen above are also defined in the statemachine.xml file. They specify a unique number for a combination of input-conditions (key, mouse and so on). See \ref InteractionPage_InteractionEvents for further information.
 
 The statemachine is compiled into an application at compile time.
 The definition of one single state machine is called the \a statemachine-pattern. Since this pattern is build up during startup with objects (states, transitions and actions) and these objects only hold information about what interaction may be done at the current state, we can also reuse the pattern. 
@@ -111,7 +111,7 @@ See mitk::Interactor
 
 \subsection InteractionPage_ExecOperations Executing Operations
 The class mitkOperation and its subclasses basically holds all information needed to execute a certain change of data.
-This change of data is only done inside the data-class itself, which is derived from the interface \a mitkOperationActor. Interactors handle the interaction through state-differentiation and combine all informations about the change in a \a mitkOperation and send this operation-object to the method ExecuteOperation (of data-class). Here the necessary data is extracted and then the change of data is performed. 
+This change of data is only done inside the data-class itself, which is derived from the interface \a mitkOperationActor. Interactors handle the interaction through state-differentiation and combine all information about the change in a \a mitkOperation and send this operation-object to the method ExecuteOperation (of data-class). Here the necessary data is extracted and then the change of data is performed. 
 
 When the operation-object, here called do-operation, is created inside the method \a ExecuteAction (in class \a mitkInteractor), an undo-operation is also created and together with the do-operation stored in an object called \a OperationEvent. After the Interactor has sent the do-operation to the data, the operation-event-object then is sent to the instance of class \a mitkUndoController, which administrates the undo-mechanism.
 

--- a/Documentation/Doxygen/3-DeveloperManual/Concepts/NewEvents.dox
+++ b/Documentation/Doxygen/3-DeveloperManual/Concepts/NewEvents.dox
@@ -6,12 +6,12 @@
 
 \section WhenUseEvents When to use this guide
 
-In general there are no restriction about how events are created and processed. The intention of this page is to provide how to contruct Events
+In general there are no restriction about how events are created and processed. The intention of this page is to provide how to construct Events
 in order to use them with the MITK Interaction Concept.
 
 \section OriginEvents Origin and processing of Events
 
-\ref DataInteractionPage gives a brief description of how events are generated and proccessed. After events are created they need to be send
+\ref DataInteractionPage gives a brief description of how events are generated and processed. After events are created they need to be send
 via mitk::RenderWindowBase::HandleEvent() so that they are relayed to a Dispatcher which handles the event distribution to the DataInteractors.
 
 \section EventImplementation Event Implementation

--- a/Documentation/Doxygen/3-DeveloperManual/Concepts/Persistence.dox
+++ b/Documentation/Doxygen/3-DeveloperManual/Concepts/Persistence.dox
@@ -3,7 +3,7 @@
 
 \tableofcontents
 
-In general, persistence referes to the capability of an application to permanently store data, settings, states, etc. so that they outlive a restart. Normal data objects, such as images, surfaces, etc., which are visible in the data storage of MITK can be saved easily by the save/load functions, see \ref DataManagementPage for more details. This page focus on the persistence of settings, configurations, object states and parameters of the application. Depending on the component, e.g. plugin, module, etc., where you want to store your settings, MITK offers various ways to do so:
+In general, persistence refers to the capability of an application to permanently store data, settings, states, etc. so that they outlive a restart. Normal data objects, such as images, surfaces, etc., which are visible in the data storage of MITK can be saved easily by the save/load functions, see \ref DataManagementPage for more details. This page focus on the persistence of settings, configurations, object states and parameters of the application. Depending on the component, e.g. plugin, module, etc., where you want to store your settings, MITK offers various ways to do so:
 -# For code inside UI independent modules with low dependencies to other libraries the mitk::PersistenceService inside the MITK persistence module can be used to store parameters by using the mitk::PropertyList class: \ref PersistenceMITKService
 -# UI dependent code where the Qt library is available can use QSettings: \ref PersistenceQTSetting
 -# If the UI setting of Plugins should be stored permanently, the persistence features of blueberry can be used: \ref PersistenceBlueberry

--- a/Documentation/Doxygen/3-DeveloperManual/Concepts/Pipelining.dox
+++ b/Documentation/Doxygen/3-DeveloperManual/Concepts/Pipelining.dox
@@ -13,7 +13,7 @@ In the real world, a pipeline connects a source of some kind with a consumer of 
 2. The pipeline, which transports the data. Many different pipeline segments can be switched in line to achieve this.
 3. The consumer, which uses the data to do something of interest.
 
-The analogy to real pipelines falls a little short in one point: A physical pipeline would never process it's contents, while in software development a pipeline usually does (this is why they are often dubbed filters as well). One might ask why one shouldn't just implement the processing logic in the consumer onject itself, since it onviously knows best what to do with it's data. The two main reasons for this are reusability and flexibility. Say, one wants to display a bone segmentation from a CT-image. Let's also assume for the sake of this introduction, that this is a simple task. One could build a monolithic class that solves the problem. Or one builds a pipeline between the displaying class and the source. We know that bones are very bright in a CT Scan, so we use a treshold filter, and then a segmentation Filter to solve the problem.
+The analogy to real pipelines falls a little short in one point: A physical pipeline would never process it's contents, while in software development a pipeline usually does (this is why they are often dubbed filters as well). One might ask why one shouldn't just implement the processing logic in the consumer onject itself, since it onviously knows best what to do with it's data. The two main reasons for this are reusability and flexibility. Say, one wants to display a bone segmentation from a CT-image. Let's also assume for the sake of this introduction, that this is a simple task. One could build a monolithic class that solves the problem. Or one builds a pipeline between the displaying class and the source. We know that bones are very bright in a CT Scan, so we use a threshold filter, and then a segmentation Filter to solve the problem.
 
 \imageMacro{pipelining_example_ct.png,"",10}
 
@@ -38,7 +38,7 @@ The flow of data inside a pipeline is triggered by only one function call to the
 
 \subsection PipelineingConceptPage_Hierarchy     The Pipeline Hierarchy
 
-Tha base class for all parts of the pipeline except the consumer (which can be of any class) is mitk::Baseprocess. This class introduces the ability to process data, has an output and may have an input as well. You will however rarly work with this class directly.
+The base class for all parts of the pipeline except the consumer (which can be of any class) is mitk::Baseprocess. This class introduces the ability to process data, has an output and may have an input as well. You will however rarly work with this class directly.
 
 \imageMacro{pipelining_hierarchy.png,"",16}
 
@@ -57,7 +57,7 @@ The filters themselves extend one of the source classes. This may not immediatel
     TestUSFilter::Pointer filter = TestUSFilter::New();
     // Make Videodevice produce it's first set of Data, so it's output isn't empty
     videoDevice->Update();
-    // attacht filter input to device output
+    // attach filter input to device output
     filter->SetInput(videoDevice->GetOutput());
     // Pipeline is now functional
     filter->Update();
@@ -79,7 +79,7 @@ mitk::Image::Pointer newOutput = mitk::Image::New();
 this->SetNthOutput(0, newOutput);
 \endverbatim
 
-- Implement MakeOutput(). This Method creats a new, clean Output that can be written to. Refer to Filters with similiar task for this.
+- Implement MakeOutput(). This Method creates a new, clean Output that can be written to. Refer to Filters with similar task for this.
 - Implement GenerateData(). This Method will generate the output based on the input it. At time of execution you can assume that the Data in input is a new set.
 
 */

--- a/Documentation/Doxygen/3-DeveloperManual/Concepts/Properties.dox
+++ b/Documentation/Doxygen/3-DeveloperManual/Concepts/Properties.dox
@@ -7,7 +7,7 @@
 
 Properties belong to a datanode and contain information relevant to the handling of the node by MITK. They provide a place to store additional information which is not part of the actual data, and as such have no reason to be contained within the data/file itself, but might be needed for such things as rendering (e.g. transfer functions) or interaction (e.g. the name of the node).
 
-Propteries can be read and set:
+Properties can be read and set:
 
 \code
 //1: Read a property
@@ -138,7 +138,7 @@ GetOpacity( opacity, BaseRenderer );
 (The BaseRenderer is usually known inside a mapper).
 
 
-  <li> reslice interpolation - This property takes effect in swivel mode or crosshair rotaiton  only. The interpolation modes "Nearest", "Linear", and "Cubic" are available and  effect the pixel outcome along the rotated plane.
+  <li> reslice interpolation - This property takes effect in swivel mode or crosshair rotation only. The interpolation modes "Nearest", "Linear", and "Cubic" are available and  effect the pixel outcome along the rotated plane.
   <li> texture interpolation - This property toggles interpolation of the texture. If enabled, edges between image pixels are blurred. If disabled, edges remain sharp.
   <li> visible - toggle node/image/surface being rendered at all
 </ul>
@@ -147,12 +147,12 @@ GetOpacity( opacity, BaseRenderer );
 
 <ul>
   <li> back color - in 2D, color of the normals outside the surface
-  <li> back normal lenth (px) - in 2D, length of the normals in pixels 
+  <li> back normal length (px) - in 2D, length of the normals in pixels 
 (When decreasing it the color using the front color is shorter?)
   <li> color mode -  (From VTK) Control how the scalar data is mapped to colors. By default (ColorModeToDefault), unsigned char scalars are treated as colors, and NOT mapped through the lookup table, while everything else is. Setting ColorModeToMapScalars means that all scalar data will be mapped through the lookup table.
   <li> draw normals 2d -  in 2D, toggles the presence of normals
   <li> front color - in 2D, color of the normals inside the surface
-  <li> front normal lenth (px) - in 2D, length of the normals in pixels 
+  <li> front normal length (px) - in 2D, length of the normals in pixels 
 (When decreasing it the color using the back color is shorter?)
   <li> invert normals - in 2D, switch front/back normals
   <li> line width - in 2D, controls the thickness of the line where the surface

--- a/Documentation/Doxygen/3-DeveloperManual/Concepts/QVTKRendering.dox
+++ b/Documentation/Doxygen/3-DeveloperManual/Concepts/QVTKRendering.dox
@@ -29,7 +29,7 @@ The main classes of the MITK rendering process can be illustrated like this:
 \imageMacro{qVtkRenderingClassOverview.png,"Rendering in MITK",16}
 
 A render request to the vtkRenderWindow does not only update the VTK pipeline, but also the MITK pipeline. However, the mitk::RenderingManager still coordinates the rendering update behavior.
-Update requests should be sent to the RenderingManager, which then, if needed, will request an update of the overall vtkRenderWindow. The vtkRenderWindow then starts to call the Render() function of all vtkRenderers, which are associated to the vtkRenderWindow. Currently, MITK uses specific vtkRenderers (outside the standard MITK rendering pipeline) for purposes, like displaying a gradient background (mitk::GradientBackground), displaying video sources (QmitkVideoBackround and mitk::VideoSource), or displaying a (department) logo (mitk::ManufacturerLogo), etc..
+Update requests should be sent to the RenderingManager, which then, if needed, will request an update of the overall vtkRenderWindow. The vtkRenderWindow then starts to call the Render() function of all vtkRenderers, which are associated to the vtkRenderWindow. Currently, MITK uses specific vtkRenderers (outside the standard MITK rendering pipeline) for purposes, like displaying a gradient background (mitk::GradientBackground), displaying video sources (QmitkVideoBackground and mitk::VideoSource), or displaying a (department) logo (mitk::ManufacturerLogo), etc..
 Despite these specific renderers, a kind of "SceneRenderer" is member of each QmitkRenderWindow. This vtkRenderer is associated with the custom vtkMitkRenderProp and is responsible for the MITK rendering.
 
 The vtkRenderer calls four different functions in vtkMitkRenderProp, namely RenderOpaqueGeometry(), RenderTranslucentPolygonalGeometry(), RenderVolumetricGeometry() and RenderOverlay(). These function calls are forwarded to the mitk::VtkPropRenderer.
@@ -109,9 +109,9 @@ However, you need to derive from the respective classes.
 In the following we provide some programming hints for writing a Vtk-based mapper:
 
 \li include mitkLocalStorageHandler.h  and derive from class BaseLocalStorage as a nested class in your own mapper. The LocalStorage instance should
-contain all VTK ressources such as actors, textures, mappers, polydata etc.
+contain all VTK resources such as actors, textures, mappers, polydata etc.
 The LocalStorageHandler is responsible for providing a LocalStorage to a concrete mitk::Mapper subclass. Each RenderWindow / mitk::BaseRenderer is
-assigned its own LocalStorage instance so that all contained ressources (actors, shaders, textures, ...) are provided individually per window.
+assigned its own LocalStorage instance so that all contained resources (actors, shaders, textures, ...) are provided individually per window.
 
 \li GenerateDataForRenderer() should be reimplemented in order to generate the primitives that should be rendered. This method is called in each Mapper::Update() pass, thus,
 all primitives that are rendered are recomputed. Employ LocalStorage::IsGenerateDataRequired() to determine whether it is necessary to generate the primitives again. It is not

--- a/Documentation/Doxygen/3-DeveloperManual/Concepts/ReaderWriterPage.md
+++ b/Documentation/Doxygen/3-DeveloperManual/Concepts/ReaderWriterPage.md
@@ -75,7 +75,7 @@ Follow these steps to implement a new Reader:
 
 A) Create a new cpp and h file in an appropriate submodule. Usually, a reader or writer should be located in the same module as the BaseData derivate it reads/writes.
 
-B) Extend AbstractFileReader . This is highly recommended because it enables integration of your Reader into the Registery. It will then automatically be used by the application to load this type of files.
+B) Extend AbstractFileReader . This is highly recommended because it enables integration of your Reader into the Registry. It will then automatically be used by the application to load this type of files.
 
 C) Provide a constructor . It should contain a minimal amount of information and might look like this:
 

--- a/Documentation/Doxygen/3-DeveloperManual/Concepts/RenderingTests.dox
+++ b/Documentation/Doxygen/3-DeveloperManual/Concepts/RenderingTests.dox
@@ -11,7 +11,7 @@ Available sections:
 
 An automatic rendering test is a powerful tool to test rendering results automatically via dashboard.
 Regarding rendering lots of different sources influence the output on the screen (e.g. different
-mappers, renderes, camera settings or the algorithm creating the data). Thus, during the rendering
+mappers, renderers, camera settings or the algorithm creating the data). Thus, during the rendering
 process of an image many different classes are involved and can have impact on the output. A minor
 change in an important class (e.g. mitkVtkPropRenderer) can have major impact on the actual rendering.
 An automatic rendering test takes an arbitrary object as input (e.g. image, surface, point set),
@@ -67,7 +67,7 @@ screen shot is highly important and has to be proven if is correct. The
 Capturing a reference screen shot should happen just once and NOT be a permanent part of the test.
 
 It is also possible to set the option -T /path/to/directory/. This option is internally used by VTK
-to save a difference image. This is meant for debugging and should not be used for the final implemenation of a test.
+to save a difference image. This is meant for debugging and should not be used for the final implementation of a test.
 
 
 \subsection RenderingTests_HowToCreateATest_Sub2 Coding the test

--- a/Documentation/Doxygen/3-DeveloperManual/Concepts/Selection.dox
+++ b/Documentation/Doxygen/3-DeveloperManual/Concepts/Selection.dox
@@ -5,7 +5,7 @@
 
 Selecting data nodes is frequently done when working with the MITK workbench.
 Most of the views in MITK require one or more selected data nodes that will be somehow processed by the underlying algorithms, such as image segmentation, image registration, basic image processing, image statistics computation etc..
-In order to overcome some disadvantages of the old data node seletion concept, the following new selection concept has been implemented.
+In order to overcome some disadvantages of the old data node selection concept, the following new selection concept has been implemented.
 <br>
 This page introduces the concept and the corresponding implementation.
 The document starts with a brief explanation of the disadvantages of the old concepts and justifies a need for the new concept.
@@ -258,7 +258,7 @@ The document starts with a brief explanation of the disadvantages of the old con
 		A plugin view can connect a function to the CurrentSelectionChanged-signal to immediately react on a new selection of the QmitkMultiNodeSelectionWidget.
 		Using QmitkAbstractNodeSelectionWidget::GetSelectedNodes the currently selected node of the selection widget can be retrieved anytime.
 
-		QmitkMultiNodeSelectionWidget::SetSelectionCheckFunction allows to define a function that puts a constraint on the node selection (dialog) to only allow specific combinations or seletions of nodes.
+		QmitkMultiNodeSelectionWidget::SetSelectionCheckFunction allows to define a function that puts a constraint on the node selection (dialog) to only allow specific combinations or selections of nodes.
 		The result of the constraint check has to be either an empty string (indicating a valid node selection) or a string that explains the error / constraint violation.
 		A simple check function can look like this:
 		\code

--- a/Documentation/Doxygen/3-DeveloperManual/Starting/GettingToKnow/DocumentationGuide.dox
+++ b/Documentation/Doxygen/3-DeveloperManual/Starting/GettingToKnow/DocumentationGuide.dox
@@ -11,7 +11,7 @@ Also, of course you need to have doxygen installed to generate documentation.
 
 \section DocumentationGuideCode Documenting the source code
 
-MITK is a substantial project and encompasses many different source files by many different developers over quite a considerable timeframe. Many of them have written excellent code which can do a lot of things and is very helpful to people who might apply it in wholly unlooked for ways to completely different problems. To facilitate this sharing and reusing of ressources one first and foremost has to know what kind of ressources are already available.
+MITK is a substantial project and encompasses many different source files by many different developers over quite a considerable timeframe. Many of them have written excellent code which can do a lot of things and is very helpful to people who might apply it in wholly unlooked for ways to completely different problems. To facilitate this sharing and reusing of resources one first and foremost has to know what kind of resources are already available.
 
 Few people write code in the intention for it to be difficult to be used by others, but unfortunately what might seem a very efficient and easily understandable piece of code to the author might be nigh unreadable for someone else. Very often it does not in fact matter whether the code itself is understandable, as long as it one can get the information what a function is supposed to do. While comments in the source file help a lot to gain this knowledge in can get quite tedious go through every file looking for the right tool.
 

--- a/Documentation/Doxygen/3-DeveloperManual/Starting/GettingToKnow/StyleGuideAndNotes.dox
+++ b/Documentation/Doxygen/3-DeveloperManual/Starting/GettingToKnow/StyleGuideAndNotes.dox
@@ -232,7 +232,7 @@ switch (actionId)
 \li Use lots of whitespace to separate logical blocks of code, intermixed with
 comments
 
-\li <b>DO NOT USE TABS.</b> The standard indention is <b>2 spaces</b> (see <a href="https://itk.org/Wiki/images/c/c6/ITKStyle.pdf">ITK Style Guide</a>). Configure your
+\li <b>DO NOT USE TABS.</b> The standard indentation is <b>2 spaces</b> (see <a href="https://itk.org/Wiki/images/c/c6/ITKStyle.pdf">ITK Style Guide</a>). Configure your
 editor accordingly.
 
 \li DO NOT USE trailing whitespaces

--- a/Documentation/Doxygen/3-DeveloperManual/Starting/GettingToKnow/Tutorial/Step05.dox
+++ b/Documentation/Doxygen/3-DeveloperManual/Starting/GettingToKnow/Tutorial/Step05.dox
@@ -11,7 +11,7 @@ https://www.mitk.org/download/tutorial-data/lungs.vtk (surface)
  A node containing a PointSet as data is added to the data tree and a PointSetDataInteractor is associated with the node, which handles the interaction.
  The @em interaction @em pattern is defined in a state-machine, stored in an external XML file. Thus, we need to load a state-machine.
 
- A state machine describes interaction pattern with different states (states beeing something like "a point is selected") and transitions to these states (e.g. "select a point").
+ A state machine describes interaction pattern with different states (states being something like "a point is selected") and transitions to these states (e.g. "select a point").
  These transitions are associated with actions. In this way it is possible to model complex interaction schemes.
  By what these transitions and actions are triggered is described in a configuration file. It maps user events to identifiers that are used in the state machine patterns.
  In this way the user interaction can be changed by simply loading a different configuration file for a state machine, and the user may add points now with a right click instead of

--- a/Documentation/Doxygen/3-DeveloperManual/Starting/GettingToKnow/Tutorial/Step06.dox
+++ b/Documentation/Doxygen/3-DeveloperManual/Starting/GettingToKnow/Tutorial/Step06.dox
@@ -51,7 +51,7 @@ MyAccessMethod(itk::Image<TPixel, VImageDimension>* itkImage)
 If you don't understand this template syntax, you should read any C++ text book. Understanding template syntax is crucial to successfully using ITK.
 
 To call this templated method with an (untemplated) mitk::Image, you can use the AccessByItk macro from mitkImageAccessByItk.h. This macro checks for
-the actual image type of the mitk::Image and does any neccessary conversions. Look into "Modules / Adaptor classes" for more information.
+the actual image type of the mitk::Image and does any necessary conversions. Look into "Modules / Adaptor classes" for more information.
 
 \code
 AccessByItk(mitkImage, MyAccessMethod)

--- a/Documentation/Doxygen/3-DeveloperManual/Starting/GettingToKnow/Tutorial/Step10.dox
+++ b/Documentation/Doxygen/3-DeveloperManual/Starting/GettingToKnow/Tutorial/Step10.dox
@@ -84,7 +84,7 @@ Please see \ref DataInteractionPage as an introduction to the MITK interaction m
 
 This tutorial is structured as follows: The first section deals with config files, describing all the parameters of events and how to use them
 in a configuration file. In the second section the basics are described that are needed to write a state machine pattern. The last section
-deals with brining configuration, state machine pattern and code together and gives an exemplary implementation of a mitk::DataInteractor.
+deals with bringing configuration, state machine pattern and code together and gives an exemplary implementation of a mitk::DataInteractor.
 
 \section ConfigFileDescriptionSection How to create a Config-File
 
@@ -255,7 +255,7 @@ For example this state machine will switch from state A to state B when the StdM
 
 \subsection EventClassSection Event Class
 
-The event class description supports the polymorphism of the event classes. Therefore state machine patters should be written in the most
+The event class description supports the polymorphism of the event classes. Therefore state machine patterns should be written in the most
 general ways possible.
 So for a given class hierarchy like this:
 \dot

--- a/Documentation/Doxygen/3-DeveloperManual/Starting/SettingUpMITK/BuildInstructions.dox
+++ b/Documentation/Doxygen/3-DeveloperManual/Starting/SettingUpMITK/BuildInstructions.dox
@@ -27,7 +27,7 @@ You need:
   -# <a href="https://www.qt.io/">Qt</a> \minimumQt5Version if you plan to develop Qt-based
      applications
   -# If you are using <b>macOS</b> you need an XCode installation and the
-     Command Line Tools as it provides the neccessary compilers and SDKs
+     Command Line Tools as it provides the necessary compilers and SDKs
 
 To build MITK on Linux, install the following packages, e. g. with APT:
 

--- a/Documentation/Doxygen/3-DeveloperManual/Starting/Starting.dox
+++ b/Documentation/Doxygen/3-DeveloperManual/Starting/Starting.dox
@@ -4,7 +4,7 @@
 
 This introduction will acquaint you with the most important workflows to get you started with your MITK development.
 First, \ref Architecture will explain the differences between the application and the toolkit.
-\ref SettingUpMITK will get you started with a working environment for MITK development. \ref GettingToKnowMITK will walk you trough the folder structure, the module system, and plugin system. This chapter also contains an extensive tutorial on how to work with MITK.
+\ref SettingUpMITK will get you started with a working environment for MITK development. \ref GettingToKnowMITK will walk you through the folder structure, the module system, and plugin system. This chapter also contains an extensive tutorial on how to work with MITK.
 The \ref FirstSteps section will then show you how to extend MITK for your own project.
 
 <ul>

--- a/Examples/DocumentationExample.h
+++ b/Examples/DocumentationExample.h
@@ -15,7 +15,7 @@ found in the LICENSE file.
 *
 * The more detailed description is needed for some more elaborate description. Here you can describe
 * anything anyone might ever want to know about your class. Of especial interest might be to mention
-* what it can be used for or what its main purpose is. If you want you can even use pictures (you migth want
+* what it can be used for or what its main purpose is. If you want you can even use pictures (you might want
 * take a look at the doxygen documentation for that).
 */
 class DocumentationExample
@@ -42,7 +42,7 @@ public:
   * @param number The position of the char to be cast. This should never be below 0 and not above the length of the char
   * array.
   * @param name A constant character pointer.
-  * @return The char value of the charakter at position number casted to int
+  * @return The char value of the character at position number casted to int
   */
   int ExampleCastCharToInt(int number, const char *name);
 

--- a/Examples/Dump/mitkdump.cpp
+++ b/Examples/Dump/mitkdump.cpp
@@ -146,7 +146,7 @@ int main(int argc, char *argv[])
   }
 
   mitk::DICOMFileReaderSelector::Pointer configSelector = mitk::DICOMFileReaderSelector::New();
-  configSelector->LoadBuiltIn3DConfigs(); // a set of compiled in ressources with standard configurations that work well
+  configSelector->LoadBuiltIn3DConfigs(); // a set of compiled in resources with standard configurations that work well
   configSelector->SetInputFiles(inputFiles);
   mitk::DICOMFileReader::Pointer reader = configSelector->GetFirstReaderWithMinimumNumberOfOutputImages();
   if (reader.IsNull())

--- a/Examples/FirstSteps/NewModule/autoload/IO/mitkExampleDataStructureWriterService.h
+++ b/Examples/FirstSteps/NewModule/autoload/IO/mitkExampleDataStructureWriterService.h
@@ -19,7 +19,7 @@ found in the LICENSE file.
 namespace mitk
 {
   /**
-  * Writes example data strucutres to a file
+  * Writes example data structures to a file
   * @ingroup Process
   */
   class ExampleDataStructureWriterService : public mitk::AbstractFileWriter

--- a/Examples/FirstSteps/NewModule/test/mitkExampleDataStructureReaderWriterTest.cpp
+++ b/Examples/FirstSteps/NewModule/test/mitkExampleDataStructureReaderWriterTest.cpp
@@ -38,7 +38,7 @@ private:
 
 public:
   /**
-  * @brief Setup Always call this method before each Test-case to ensure correct and new intialization of the used
+  * @brief Setup Always call this method before each Test-case to ensure correct and new initialization of the used
   * members for a new test case. (If the members are not used in a test, the method does not need to be called).
   */
   void setUp() override

--- a/Examples/FirstSteps/NewModule/test/mitkExampleDataStructureTest.cpp
+++ b/Examples/FirstSteps/NewModule/test/mitkExampleDataStructureTest.cpp
@@ -37,7 +37,7 @@ private:
 
 public:
   /**
-  * @brief Setup Always call this method before each Test-case to ensure correct and new intialization of the used
+  * @brief Setup Always call this method before each Test-case to ensure correct and new initialization of the used
   * members for a new test case. (If the members are not used in a test, the method does not need to be called).
   */
   void setUp() override

--- a/Examples/Plugins/org.mitk.example.gui.customviewer.views/src/internal/DicomView.h
+++ b/Examples/Plugins/org.mitk.example.gui.customviewer.views/src/internal/DicomView.h
@@ -50,7 +50,7 @@ public:
   /**
    * Creates the view control widgets provided by the QmitkDicomExternalDataWidget class.
    * Widgets associated with unused functionality are being removed and DICOM import and data
-   * storage transfer funcionality being connected to the appropriate slots.
+   * storage transfer functionality being connected to the appropriate slots.
    */
   void CreateQtPartControl(QWidget *parent) override;
 

--- a/Examples/Plugins/org.mitk.example.gui.customviewer/documentation/doxygen/CustomViewerExample.dox
+++ b/Examples/Plugins/org.mitk.example.gui.customviewer/documentation/doxygen/CustomViewerExample.dox
@@ -149,7 +149,7 @@ For our purposes, we want to place the QtPerspectiveSwitcherTabBar and the View-
 \skip for correct initial layout
 \until this->GetWindowConfigurer
 
-The OpenFile-Button and the QtPerspectiveSwitcherTabBar will be laid out together in a HBoxLayout called PerspectivesLayer. The PerspectivesLayer will be vertically arranged with the PageComposite widget in a VBoxLayout called CentralWidgetLayout. This CentralWidgetLayout will be assigned a QWidget being set the CentralWidget of our MainWindow. Caveat: we need to call the activate- and update-Methods of our CentralWidgetLayout; otherweise the widgets will not be laid out properly. See Bug-1654 for further details. See our bulk custom viewer application depicted below.
+The OpenFile-Button and the QtPerspectiveSwitcherTabBar will be laid out together in a HBoxLayout called PerspectivesLayer. The PerspectivesLayer will be vertically arranged with the PageComposite widget in a VBoxLayout called CentralWidgetLayout. This CentralWidgetLayout will be assigned a QWidget being set the CentralWidget of our MainWindow. Caveat: we need to call the activate- and update-Methods of our CentralWidgetLayout; otherwise the widgets will not be laid out properly. See Bug-1654 for further details. See our bulk custom viewer application depicted below.
 
 \imageMacro{BulkApplicationWindow.png,"Our bulk application showing two empty perspectives managed with a tab-bar based perspectives bar",16.00}
 
@@ -243,7 +243,7 @@ In it, a dialog is opened that asks for the user for a number of files to open. 
 
 \snippet CustomViewerWorkbenchWindowAdvisor.cpp WorkbenchWindowAdvisorOpenFilePerspActive
 
-Before we can examine the loaded data, we have to manually invoke a reinit on it. The render window concept in mitk is actually undergoing some work, where this inconvenience will also be adressed. The images below show the resulting file opening functionality.
+Before we can examine the loaded data, we have to manually invoke a reinit on it. The render window concept in mitk is actually undergoing some work, where this inconvenience will also be addressed. The images below show the resulting file opening functionality.
 
 \imageMacro{OpenFileDialog.png,"The open file dialog",16.00}
 \imageMacro{FileOpened.png,"Opened file shown in the render window view",16.00}
@@ -261,12 +261,12 @@ In a final step, we want to further customize the appearance of our mainWindow t
 <LI> DICOM Import functionality </LI>
 </UL>
 
-For GUI customization, we will modify the Qt-Stylesheets files already used by blueberry applications. Within the Qt-Stylesheet-Files, all widgets can globally and locally be adressed inside the main window for style changes. We have to adress the berry::IQtStyleManager to tell the BlueBerry workbench to use a specific Qt-Stylesheet. This is done inside the WorkbenchAdvisor in the CustomViewerWorkbenchAdvisor::Initialize() method:
+For GUI customization, we will modify the Qt-Stylesheets files already used by blueberry applications. Within the Qt-Stylesheet-Files, all widgets can globally and locally be addressed inside the main window for style changes. We have to address the berry::IQtStyleManager to tell the BlueBerry workbench to use a specific Qt-Stylesheet. This is done inside the WorkbenchAdvisor in the CustomViewerWorkbenchAdvisor::Initialize() method:
 
 \snippet CustomViewerWorkbenchAdvisor.cpp WorkbenchAdvisorInit
 
 The style manager is taken from the application's plugin context via service reference. Invoking the berry::IQtStyleManager::AddStyle() and berry::IQtStyleManager::SetStyle() methods, the workbench will now use the announced qss-File to style our Workbench Window. In a production system, the stylesheets are usually compiled into the plug-in or application using the Qt resource system.
-However, during developement of the stylesheets it is often more convenient to reference them using a hard-coded path to the local file system (see live update functionality below).
+However, during development of the stylesheets it is often more convenient to reference them using a hard-coded path to the local file system (see live update functionality below).
 
 Before we start customization we will first provide some customization convenience. We add an UpdateStyle()-slot to our CustomViewerWorkbenchWindowAdvisor where we explicitly reset the css-File to the style manager:
 

--- a/Examples/Plugins/org.mitk.example.gui.customviewer/src/internal/QtPerspectiveSwitcherTabBar.cpp
+++ b/Examples/Plugins/org.mitk.example.gui.customviewer/src/internal/QtPerspectiveSwitcherTabBar.cpp
@@ -17,7 +17,7 @@ found in the LICENSE file.
 #include <berryIWorkbenchPage.h>
 
 /**
- * \brief A Listener class for perspective changes. Neccessary for consistent tab activation
+ * \brief A Listener class for perspective changes. Necessary for consistent tab activation
  * in QtPerspectiveSwitcherTabBar instances.
  */
 // //! [SwitchPerspectiveListener]

--- a/Examples/Plugins/org.mitk.example.gui.customviewer/src/internal/QtPerspectiveSwitcherTabBar.h
+++ b/Examples/Plugins/org.mitk.example.gui.customviewer/src/internal/QtPerspectiveSwitcherTabBar.h
@@ -57,12 +57,12 @@ private:
   QHash<QString, QAction *> perspIdToActionMap;
 
   /**
-   * Neccessary to prevent initial tab switching.
+   * Necessary to prevent initial tab switching.
    */
   bool tabChanged;
 
   /**
-   * Listener for perspective changes. Neccessary for consistent tab activation.
+   * Listener for perspective changes. Necessary for consistent tab activation.
    */
   friend struct QtPerspectiveSwitcherTabBarListener;
 };

--- a/Examples/Plugins/org.mitk.example.gui.extensionpointdefinition/documentation/doxygen/ExampleExtensionPoint.dox
+++ b/Examples/Plugins/org.mitk.example.gui.extensionpointdefinition/documentation/doxygen/ExampleExtensionPoint.dox
@@ -18,7 +18,7 @@
   These created push buttons are connected to the ChangeText method that alters the input text (in the way the extension defines) and outputs the changed text in another text field.
   \snippet MinimalView.cpp Use extended functionality to alter input text
 
-  The plugin can now be extened by extensions provided by other plugins.
+  The plugin can now be extended by extensions provided by other plugins.
 
   View complete source files:
   \li \github{Examples/Plugins/org.mitk.example.gui.extensionpointdefinition/src/internal/ChangeTextDescriptor.cpp,ChangeTextDescriptor.cpp}

--- a/Examples/Plugins/org.mitk.example.gui.extensionpointdefinition/documentation/doxygen/modules.dox
+++ b/Examples/Plugins/org.mitk.example.gui.extensionpointdefinition/documentation/doxygen/modules.dox
@@ -2,7 +2,7 @@
   \defgroup org_mitk_example_gui_extensionpointdefinition org.mitk.example.gui.extensionpointdefinition
   \ingroup MITKExamplePlugins
 
-  \brief A minimal applictaion that definines an extension point and collects extensions.
+  \brief A minimal applictaion that defines an extension point and collects extensions.
 */
 
 /**

--- a/Examples/Plugins/org.mitk.example.gui.imaging/documentation/UserManual/QmitkIsoSurfaceUserManual.dox
+++ b/Examples/Plugins/org.mitk.example.gui.imaging/documentation/UserManual/QmitkIsoSurfaceUserManual.dox
@@ -12,7 +12,7 @@ Available sections:
 
 \section QmitkIsoSurfaceUserManualOverview Overview
 
-IsoSurface is a program module for creating surfaces (e.g. polygon structures) out of images. The user defines a threshold that seperates object and background inside the image. Pixels that belong to the object need grey values below the threshold. Pixles with grey values above the threshold will be ignored. The result is a polygon object 
+IsoSurface is a program module for creating surfaces (e.g. polygon structures) out of images. The user defines a threshold that separates object and background inside the image. Pixels that belong to the object need grey values below the threshold. Pixles with grey values above the threshold will be ignored. The result is a polygon object 
 that can be saved as an *.stl-object. 
 
 \section QmitkIsoSurfaceUserManualFeatures Features

--- a/Examples/Plugins/org.mitk.example.gui.imaging/documentation/UserManual/QmitkSimpleExampleUserManual.dox
+++ b/Examples/Plugins/org.mitk.example.gui.imaging/documentation/UserManual/QmitkSimpleExampleUserManual.dox
@@ -13,7 +13,7 @@ It offers:
 <li>A button "Re-Initialize Navigators" to reinitialize those sliders to their initial position (Slice and time position 0)
 <li>A button "Take Screenshot" to take a screenshot of the chosen window (Axial, Sagittal, Coronal, 3D)
 <li>A button "Take HighDef 3D Screenshot" to take an high resolution screenshot of the 3D scene
-<li>A button "Generate Movie" whichs takes a movie of the chosen window by scrolling either through all slices (Axial, Sagittal, Coronal). Please use the MovieMaker view for recording a movie of a rotating 3D scene.
+<li>A button "Generate Movie" which takes a movie of the chosen window by scrolling either through all slices (Axial, Sagittal, Coronal). Please use the MovieMaker view for recording a movie of a rotating 3D scene.
 <li>A selection box where the 3D view can be transformed into either a red-blue stereo or a D4D stereo view
 </ul>
 */

--- a/Examples/Plugins/org.mitk.example.gui.imaging/src/ExamplesDll.h
+++ b/Examples/Plugins/org.mitk.example.gui.imaging/src/ExamplesDll.h
@@ -18,7 +18,7 @@ found in the LICENSE file.
 // from a DLL simpler. All files within this DLL are compiled with the org_mitk_gui_qt_examples_EXPORTS
 // symbol defined on the command line. this symbol should not be defined on any project
 // that uses this DLL. This way any other project whose source files include this file see
-// org_mitk_gui_qt_examples_EXPORTS functions as being imported from a DLL, wheras this DLL sees symbols
+// org_mitk_gui_qt_examples_EXPORTS functions as being imported from a DLL, whereas this DLL sees symbols
 // defined with this macro as being exported.
 //
 #if defined(_WIN32) && !defined(MITK_STATIC)

--- a/Examples/Plugins/org.mitk.example.gui.imaging/src/internal/surfaceutilities/mitkSurfaceToPointSetFilter.h
+++ b/Examples/Plugins/org.mitk.example.gui.imaging/src/internal/surfaceutilities/mitkSurfaceToPointSetFilter.h
@@ -22,7 +22,7 @@ namespace mitk
   /** Documentation
    *  @brief This filter converts the input surface into a point set. The output point set contains every point exactly
    * one time
-   *         (no dublicated points like in the stl-format).
+   *         (no duplicated points like in the stl-format).
    */
 
   class SurfaceToPointSetFilter : public mitk::PointSetSource

--- a/Examples/Plugins/org.mitk.example.gui.multipleperspectives/documentation/doxygen/MultiplePerspectives.dox
+++ b/Examples/Plugins/org.mitk.example.gui.multipleperspectives/documentation/doxygen/MultiplePerspectives.dox
@@ -18,7 +18,7 @@
   The perspective bar:
   \image html Perspectivebar.png
 
-  The icons of the perspectives are definded by the extension declaration in the plugin.xml
+  The icons of the perspectives are defined by the extension declaration in the plugin.xml
   of the example and lie in the resources directory of the plug-in:
   \include org.mitk.example.gui.multipleperspectives/plugin.xml
 

--- a/Examples/Plugins/org.mitk.example.gui.selectionservicemitk.views/manifest_headers.cmake
+++ b/Examples/Plugins/org.mitk.example.gui.selectionservicemitk.views/manifest_headers.cmake
@@ -1,4 +1,4 @@
-set(Plugin-Name "MITK Example: Seletion service MITK")
+set(Plugin-Name "MITK Example: Selection service MITK")
 set(Plugin-Version "1.0.0")
 set(Plugin-Vendor "German Cancer Research Center (DKFZ)")
 set(Plugin-ContactAddress "https://www.mitk.org")

--- a/Examples/Plugins/org.mitk.example.gui.selectionservicemitk.views/src/internal/ListenerViewMitk.h
+++ b/Examples/Plugins/org.mitk.example.gui.selectionservicemitk.views/src/internal/ListenerViewMitk.h
@@ -51,7 +51,7 @@ protected:
   void SetFocus() override;
 
   //! [MITK Selection Listener method]
-  /** @brief Reimplemention of method from QmitkAbstractView that implements the selection listener functionality.
+  /** @brief Reimplementation of method from QmitkAbstractView that implements the selection listener functionality.
    * @param part The workbench part responsible for the selection change.
    * @param nodes A list of selected nodes.
    *
@@ -65,7 +65,7 @@ protected:
 private Q_SLOTS:
 
   /** @brief Simple slot function that changes the selection of the radio buttons according to the passed string.
-   * @param selectStr QString that contains the name of the slected list element
+   * @param selectStr QString that contains the name of the selected list element
    *
    */
   void ToggleRadioMethod(QString selectStr);

--- a/Examples/Plugins/org.mitk.example.gui.selectionservicemitk/documentation/doxygen/SelectionServiceMitk.dox
+++ b/Examples/Plugins/org.mitk.example.gui.selectionservicemitk/documentation/doxygen/SelectionServiceMitk.dox
@@ -9,7 +9,7 @@
   This example is an alternative for the Qt selection service described in the previous example. The
   selection service is based on MITK data nodes. Again the selection service is used to connect the
   selection of QListWidgetItems of the SelectionView with the radio buttons from the ListenerView and the
-  funtionality is the same.
+  functionality is the same.
 
   This time the SelectionView does not inherit from berry::QtViewPart but from QmitkAbstractView. QmitkAbstractView provides
   a virtual method called GetDataNodeSelectionModel() with which the

--- a/Examples/Plugins/org.mitk.example.gui.selectionservicemitk/manifest_headers.cmake
+++ b/Examples/Plugins/org.mitk.example.gui.selectionservicemitk/manifest_headers.cmake
@@ -1,4 +1,4 @@
-set(Plugin-Name "MITK Example: Seletion service MITK")
+set(Plugin-Name "MITK Example: Selection service MITK")
 set(Plugin-Version "1.0.0")
 set(Plugin-Vendor "German Cancer Research Center (DKFZ)")
 set(Plugin-ContactAddress "https://www.mitk.org")

--- a/Examples/Plugins/org.mitk.example.gui.selectionserviceqt/documentation/doxygen/SelectionServiceQt.dox
+++ b/Examples/Plugins/org.mitk.example.gui.selectionserviceqt/documentation/doxygen/SelectionServiceQt.dox
@@ -13,7 +13,7 @@
   (the selection listener) does not provide any selection events. If the user changes the radio button state
   the QListWidget is not altered.
 
-  For additional informations on the selection service concept see https://www.mitk.org/wiki/Article_Using_the_Selection_Service
+  For additional information on the selection service concept see https://www.mitk.org/wiki/Article_Using_the_Selection_Service
 
   The berry::QtSelectionProvider class implements the interface berry::ISelectionProvider. Due to the model/view concept in Qt, the workbench
   provides the berry::QtSelectionProvider class for Qt viewers which must be provided with a QItemSelectionModel.

--- a/Examples/Plugins/org.mitk.example.gui.selectionserviceqt/manifest_headers.cmake
+++ b/Examples/Plugins/org.mitk.example.gui.selectionserviceqt/manifest_headers.cmake
@@ -1,4 +1,4 @@
-set(Plugin-Name "MITK Example: Seletion service QT")
+set(Plugin-Name "MITK Example: Selection service QT")
 set(Plugin-Version "1.0.0")
 set(Plugin-Vendor "German Cancer Research Center (DKFZ)")
 set(Plugin-ContactAddress "https://www.mitk.org")

--- a/Examples/Plugins/org.mitk.example.gui.selectionserviceqt/src/internal/ListenerView.h
+++ b/Examples/Plugins/org.mitk.example.gui.selectionserviceqt/src/internal/ListenerView.h
@@ -51,7 +51,7 @@ private Q_SLOTS:
 
   /**
    * @brief Simple slot function that changes the selection of the radio buttons according to the passed string.
-   * @param selectStr QString that contains the name of the slected list element
+   * @param selectStr QString that contains the name of the selected list element
    */
   void ToggleRadioMethod(QString selectStr);
 

--- a/Examples/Tutorial/Step5/Step5.cpp
+++ b/Examples/Tutorial/Step5/Step5.cpp
@@ -42,7 +42,7 @@ found in the LICENSE file.
 //## on which the interactor reacts (e.g., which mouse buttons are used to
 //## set a point), the @em transition to the next state (e.g., the initial
 //## may be "empty point set") and associated @a actions (e.g., add a point
-//## at the position where the mouse-click occured).
+//## at the position where the mouse-click occurred).
 int main(int argc, char *argv[])
 {
   QApplication qtapplication(argc, argv);

--- a/MITKCPackOptions.cmake.in
+++ b/MITKCPackOptions.cmake.in
@@ -3,7 +3,7 @@ if(CPACK_GENERATOR MATCHES "NSIS")
 
   # set the package header icon for MUI
   set(CPACK_PACKAGE_ICON "@MITK_SOURCE_DIR@\\mitk.bmp")
-  # set the install/unistall icon used for the installer itself
+  # set the install/uninstall icon used for the installer itself
   # There is a bug in NSIS that does not handle full unix paths properly. 
   set(CPACK_NSIS_MUI_ICON "@MITK_SOURCE_DIR@\\mitk.ico")
   set(CPACK_NSIS_MUI_UNIICON "@MITK_SOURCE_DIR@\\mitk.ico")

--- a/MITKConfig.cmake.in
+++ b/MITKConfig.cmake.in
@@ -174,7 +174,7 @@ set(CMAKE_MODULE_PATH ${MITK_CMAKE_MODULE_PATH} ${CMAKE_MODULE_PATH})
 if(MITK_USE_DCMTK)
   # Due to the preferred CONFIG mode in find_package calls above,
   # the DCMTKConfig.cmake file is read, which does not provide useful
-  # package information. We explictly need MODULE mode to find DCMTK.
+  # package information. We explicitly need MODULE mode to find DCMTK.
   if(${_dcmtk_dir_orig} MATCHES "${MITK_EXTERNAL_PROJECT_PREFIX}.*")
     # Help our FindDCMTK.cmake script find our super-build DCMTK
     set(DCMTK_DIR ${MITK_EXTERNAL_PROJECT_PREFIX})
@@ -190,7 +190,7 @@ endif()
 if(MITK_USE_DCMQI)
   # Due to the preferred CONFIG mode in find_package calls above,
   # the DCMQIConfig.cmake file is read, which does not provide useful
-  # package information. We explictly need MODULE mode to find DCMQI.
+  # package information. We explicitly need MODULE mode to find DCMQI.
     # Help our FindDCMQI.cmake script find our super-build DCMQI
   set(DCMQI_DIR ${MITK_EXTERNAL_PROJECT_PREFIX})
   find_package(DCMQI REQUIRED)

--- a/Plugins/org.blueberry.core.commands/src/common/berryNamedHandleObject.h
+++ b/Plugins/org.blueberry.core.commands/src/common/berryNamedHandleObject.h
@@ -39,7 +39,7 @@ protected:
   QString description;
 
   /**
-   * The name of this handle. This valud should not be <code>null</code>
+   * The name of this handle. This value should not be <code>null</code>
    * unless the handle is undefined.
    */
   QString name;

--- a/Plugins/org.blueberry.core.runtime/src/internal/berryExtensionRegistry.cpp
+++ b/Plugins/org.blueberry.core.runtime/src/internal/berryExtensionRegistry.cpp
@@ -903,7 +903,7 @@ ExtensionRegistry::~ExtensionRegistry()
 
 void ExtensionRegistry::Stop(QObject* /*key*/)
 {
-  // If the registry creator specified a key token, check that the key mathches it
+  // If the registry creator specified a key token, check that the key matches it
   // (it is assumed that registry owner keeps the key to prevent unautorized access).
   if (masterToken != nullptr && masterToken != nullptr)
   {

--- a/Plugins/org.blueberry.core.runtime/src/internal/berryExtensionsParser.cpp
+++ b/Plugins/org.blueberry.core.runtime/src/internal/berryExtensionsParser.cpp
@@ -399,7 +399,7 @@ void ExtensionsParser::logStatus(const QXmlParseException& ex)
     msg = QString("Parsing error: \"%1\"").arg(ex.message());
   else
     msg = QString("Parsing error in \"%1\" [line %2, column %3]: \"%4\".").arg(name)
-        .arg(ex.lineNumber()).arg(ex.columnNumber()).arg(ex.message());
+        .arg(ex.lineNumber()).arg(ex.columnumber()).arg(ex.message());
   IStatus::Pointer status(new Status(IStatus::WARNING_TYPE, RegistryMessages::OWNER_NAME,
                                      PARSE_PROBLEM, msg, BERRY_STATUS_LOC));
   error(status);

--- a/Plugins/org.blueberry.ui.qt.help/src/internal/berryQHelpEngineWrapper.cpp
+++ b/Plugins/org.blueberry.ui.qt.help/src/internal/berryQHelpEngineWrapper.cpp
@@ -25,7 +25,7 @@ QHelpEngineWrapper::QHelpEngineWrapper(const QString &collectionFile)
    * because we will start to index them, only to be interrupted
    * by the next request. Also, there is a nasty SQLITE bug that will
    * cause the application to hang for minutes in that case.
-   * This call is reverted by initalDocSetupDone(), which must be
+   * This call is reverted by initialDocSetupDone(), which must be
    * called after the new docs have been installed.
    */
   disconnect(this, SIGNAL(setupFinished()),

--- a/Plugins/org.blueberry.ui.qt/src/internal/berryParameterValueConverterProxy.h
+++ b/Plugins/org.blueberry.ui.qt/src/internal/berryParameterValueConverterProxy.h
@@ -22,7 +22,7 @@ namespace berry {
 struct IConfigurationElement;
 
 /**
- * A proxy for a parameter value converter that has been defined in the regisry.
+ * A proxy for a parameter value converter that has been defined in the registry.
  * This delays the class loading until the converter is really asked to do
  * string/object conversions.
  */

--- a/Plugins/org.blueberry.ui.qt/src/internal/berryRegistryReader.h
+++ b/Plugins/org.blueberry.ui.qt/src/internal/berryRegistryReader.h
@@ -130,7 +130,7 @@ public:
      * supplied plugin ID and extension point.
      *
      * @param registry the registry to read from
-     * @param pluginId the plugin id of the extenion point
+     * @param pluginId the plugin id of the extension point
      * @param extensionPoint the extension point id
      */
     virtual void ReadRegistry(IExtensionRegistry* registry,

--- a/Plugins/org.blueberry.ui.qt/src/internal/berryWorkbench.cpp
+++ b/Plugins/org.blueberry.ui.qt/src/internal/berryWorkbench.cpp
@@ -1194,7 +1194,7 @@ IWorkbenchPage::Pointer Workbench::ShowPerspective(
 
   // If another window that has the workspace root as input and the
   // requested
-  // perpective open and active, then the window is given focus.
+  // perspective open and active, then the window is given focus.
   IAdaptable* input = GetDefaultPageInput();
   QList<IWorkbenchWindow::Pointer> windows(GetWorkbenchWindows());
   for (int i = 0; i < windows.size(); i++)
@@ -1326,7 +1326,7 @@ IWorkbenchPage::Pointer Workbench::ShowPerspective(
   //    }
   //
   //    // If another window has the requested input and the requested
-  //    // perpective open and active, then that window is given focus.
+  //    // perspective open and active, then that window is given focus.
   //    IWorkbenchWindow[] windows = getWorkbenchWindows();
   //    for (int i = 0; i < windows.length; i++) {
   //      win = (WorkbenchWindow) windows[i];

--- a/Plugins/org.blueberry.ui.qt/src/internal/berryWorkbenchPage.h
+++ b/Plugins/org.blueberry.ui.qt/src/internal/berryWorkbenchPage.h
@@ -1248,7 +1248,7 @@ protected:
   QList<SmartPointer<Perspective> > GetOpenInternalPerspectives();
 
   /**
-   * Checks perspectives in the order they were activiated
+   * Checks perspectives in the order they were activated
    * for the specified part.  The first sorted perspective
    * that contains the specified part is returned.
    *

--- a/Plugins/org.mitk.gui.common/src/mitkIRenderWindowPart.h
+++ b/Plugins/org.mitk.gui.common/src/mitkIRenderWindowPart.h
@@ -129,7 +129,7 @@ struct MITK_GUI_COMMON_PLUGIN IRenderWindowPart {
   virtual void InitializeViews(const mitk::TimeGeometry* geometry, bool resetCamera) = 0;
 
   /**
-  * @brief Define the reference geometry for interaction withing a render window.
+  * @brief Define the reference geometry for interaction within a render window.
   *
   *        The concrete implementation is subclass-specific, no default implementation is provided here.
   *        An implementation can be found in 'QmitkAbstractMultiWidgetEditor' and will just

--- a/Plugins/org.mitk.gui.qt.dicombrowser/documentation/UserManual/QmitkDicom.dox
+++ b/Plugins/org.mitk.gui.qt.dicombrowser/documentation/UserManual/QmitkDicom.dox
@@ -15,7 +15,7 @@ The DICOM browser allows you to navigate the DICOM folder/cd depending on its me
 and import selected series for viewing in your MITK based application.
 It also allows you to store your dicom data in an internal database so you can easily access often used dicom images.
 
-It is based on the <a href="https://commontk.org/index.php/Documentation/DICOM_Overview">commonTK (CTK) DICOM funcionality</a>.
+It is based on the <a href="https://commontk.org/index.php/Documentation/DICOM_Overview">commonTK (CTK) DICOM functionality</a>.
 
 \section org_mitk_gui_qt_dicomDataHandling Data handling
 \imageMacro{QmitkDicom_PluginControls.png,"The dicom Plugin controls",7.37}

--- a/Plugins/org.mitk.gui.qt.igt.app.hummelprotocolmeasurements/src/internal/QmitkIGTTrackingDataEvaluationView.cpp
+++ b/Plugins/org.mitk.gui.qt.igt.app.hummelprotocolmeasurements/src/internal/QmitkIGTTrackingDataEvaluationView.cpp
@@ -220,7 +220,7 @@ void QmitkIGTTrackingDataEvaluationView::OnOrientationCalculation_CalcRef()
     for (unsigned int j = 0; j < myPlayer->GetNumberOfOutputs(); ++j)
       myEvaluationFilter->SetInput(j, myPlayer->GetOutput(j));
 
-    //update pipline until number of samples is reached
+    //update pipeline until number of samples is reached
     for (int j = 0; j < m_Controls->m_NumberOfSamples->value(); ++j)
       myEvaluationFilter->Update();
 
@@ -465,7 +465,7 @@ void QmitkIGTTrackingDataEvaluationView::OnEvaluateData()
       return;
     }
 
-    //update pipline until number of samples is reached
+    //update pipeline until number of samples is reached
     for (int j = 0; j < m_Controls->m_NumberOfSamples->value(); j++)
       myEvaluationFilter->Update();
 
@@ -511,7 +511,7 @@ void QmitkIGTTrackingDataEvaluationView::OnGeneratePointSetsOfSinglePositions()
     myPlayer->SetFiletype(mitk::NavigationDataCSVSequentialPlayer::ManualLoggingCSV);
     myPlayer->SetFileName(m_FilenameVector.at(i));
 
-    //update pipline until number of samlples is reached and store every single point
+    //update pipeline until number of samlples is reached and store every single point
     for (int j = 0; j < m_Controls->m_NumberOfSamples->value(); j++)
     {
       myPlayer->Update();
@@ -551,7 +551,7 @@ void QmitkIGTTrackingDataEvaluationView::OnGeneratePointSet()
     //connect pipeline
     for (unsigned int j = 0; j < myPlayer->GetNumberOfOutputs(); ++j) { myEvaluationFilter->SetInput(j, myPlayer->GetOutput(j)); }
 
-    //update pipline until number of samlples is reached
+    //update pipeline until number of samlples is reached
     for (int j = 0; j < m_Controls->m_NumberOfSamples->value(); ++j) { myEvaluationFilter->Update(); }
 
     //add mean position to point set
@@ -593,7 +593,7 @@ void QmitkIGTTrackingDataEvaluationView::OnGenerateRotationLines()
     //connect pipeline
     for (unsigned int j = 0; j < myPlayer->GetNumberOfOutputs(); ++j) { myEvaluationFilter->SetInput(j, myPlayer->GetOutput(j)); }
 
-    //update pipline until number of samlples is reached
+    //update pipeline until number of samlples is reached
     for (int j = 0; j < m_Controls->m_NumberOfSamples->value(); ++j)
       myEvaluationFilter->Update();
 
@@ -928,7 +928,7 @@ std::vector<mitk::NavigationDataEvaluationFilter::Pointer> QmitkIGTTrackingDataE
     for (unsigned int j = 0; j < myPlayer->GetNumberOfOutputs(); ++j)
       myEvaluationFilter->SetInput(j, myPlayer->GetOutput(j));
 
-    //update pipline until number of samlples is reached
+    //update pipeline until number of samlples is reached
     for (int j = 0; j < m_Controls->m_NumberOfSamples->value(); ++j)
       myEvaluationFilter->Update();
 

--- a/Plugins/org.mitk.gui.qt.igt.app.ultrasoundtrackingnavigation/src/internal/NavigationStepWidgets/QmitkUSNavigationStepPlacementPlanning.ui
+++ b/Plugins/org.mitk.gui.qt.igt.app.ultrasoundtrackingnavigation/src/internal/NavigationStepWidgets/QmitkUSNavigationStepPlacementPlanning.ui
@@ -115,7 +115,7 @@
    <item>
     <widget class="QGroupBox" name="groupBox_2">
      <property name="title">
-      <string>Placment by Mouse Click</string>
+      <string>Placement by Mouse Click</string>
      </property>
      <layout class="QVBoxLayout" name="verticalLayout_3">
       <item>

--- a/Plugins/org.mitk.gui.qt.igt.app.ultrasoundtrackingnavigation/src/internal/QmitkUltrasoundCalibration.cpp
+++ b/Plugins/org.mitk.gui.qt.igt.app.ultrasoundtrackingnavigation/src/internal/QmitkUltrasoundCalibration.cpp
@@ -393,7 +393,7 @@ void QmitkUltrasoundCalibration::OnStartCalibrationProcess()
 
   m_CombinedModality = m_Controls.m_CombinedModalityManagerWidget->GetSelectedCombinedModality();
   m_CombinedModality->SetCalibration(mitk::AffineTransform3D::New()); // dummy calibration because without a calibration
-                                                                      // the comined modality was laggy (maybe a bug?)
+                                                                      // the combined modality was laggy (maybe a bug?)
   if (m_CombinedModality.IsNull())
   {
     return;

--- a/Plugins/org.mitk.gui.qt.igtexamples/documentation/UserManual/QmitkIGTTutorial.dox
+++ b/Plugins/org.mitk.gui.qt.igtexamples/documentation/UserManual/QmitkIGTTutorial.dox
@@ -45,7 +45,7 @@ Let's now have a deeper look at these functions.
 
 \snippet QmitkIGTTutorialView.cpp OnStart 1
 
-We first check in a try environment, if we should use an NDI tracking device or a virtual device. Let's start with NDI, we hardcode the parameters here and give out a warning. In your proper application, the parameters should be set via the gui aswell (see \ref org_mitk_views_igttrackingtoolbox ), but for simplicity, we just set hardcoded parameters here. If you want to try it with your own NDI device, you need to adapt these parameters here in the code:
+We first check in a try environment, if we should use an NDI tracking device or a virtual device. Let's start with NDI, we hardcode the parameters here and give out a warning. In your proper application, the parameters should be set via the gui as well (see \ref org_mitk_views_igttrackingtoolbox ), but for simplicity, we just set hardcoded parameters here. If you want to try it with your own NDI device, you need to adapt these parameters here in the code:
 
 \snippet QmitkIGTTutorialView.cpp OnStart 2
 

--- a/Plugins/org.mitk.gui.qt.igtexamples/src/internal/QmitkIGTTrackingLabView.h
+++ b/Plugins/org.mitk.gui.qt.igtexamples/src/internal/QmitkIGTTrackingLabView.h
@@ -73,7 +73,7 @@ void SetFocus() override;
 
 protected slots:
 
-/** This timer updates the IGT pipline, when necessary:
+/** This timer updates the IGT pipeline, when necessary:
 *   1: if permanent registration is activated, then the permanent
 *      registration filter has to be updated
 *   2: if the camera view is on it also must be updated
@@ -159,7 +159,7 @@ void DestroyIGTPipeline();
 //####################### Members for the IGT pipeline ######################################
 // The IGT pipeline is basically initialized in the method OnSetupNavigation(). Further initialization
 // is done in the methods OnPermanentRegistration(), OnPointSetRecording() and OnVirtualCamera().
-// The pipline is updated in the method UpdateTimer(). When the complete pipeline is active, it is
+// The pipeline is updated in the method UpdateTimer(). When the complete pipeline is active, it is
 // structured as follows:
 //          ,-> m_PermanentRegistrationFilter
 // m_Source -> m_Visualizer

--- a/Plugins/org.mitk.gui.qt.igttracking/documentation/UserManual/QmitkMITKIGTNavigationToolCalibration.dox
+++ b/Plugins/org.mitk.gui.qt.igttracking/documentation/UserManual/QmitkMITKIGTNavigationToolCalibration.dox
@@ -50,7 +50,7 @@ Click on Start Edit Tooltip and in the new window you can enter the values for t
 After you entered the values you can click "Use Manipulated ToolTip" to perform the Calibration on the Tool to calibrate. The box "Current Tool Tip Orientation" will show you the results. It will list the resulting values of the Quaternion, the Euler Angles and the Matrix.
 \imageMacro{QmitkIGTTracking_ToolCalibration_Manual_After.png,"MITK Screenshot of the Current Tool Tip Orientation Box after the tool was manually calibrated",5.00}
 To save the result permanently just click "Save Calibrated Navigation Tool" and you can save the calibrated tool as an IGTTool for later use with your tracking device in a navigation application.
-If you are not satisfied with the results you can click "Start Edit Tooltip" again and either change the values for the rotation and translation again or just reset everything by clicking on "Reset to Identity". To write the new values or resetted values into the tool just click "Use Manipulated Tool Tip" again. Now you can save your relust just as described above.
+If you are not satisfied with the results you can click "Start Edit Tooltip" again and either change the values for the rotation and translation again or just reset everything by clicking on "Reset to Identity". To write the new values or reset values into the tool just click "Use Manipulated Tool Tip" again. Now you can save your relust just as described above.
 
 \subsection QmitkMITKIGTNavigationToolCalibrationReference Tool Tip Calibration with a single Reference Tool
 

--- a/Plugins/org.mitk.gui.qt.igttracking/src/internal/QmitkMITKIGTTrackingToolboxView.h
+++ b/Plugins/org.mitk.gui.qt.igttracking/src/internal/QmitkMITKIGTTrackingToolboxView.h
@@ -97,7 +97,7 @@ class QmitkMITKIGTTrackingToolboxView : public QmitkAbstractView
     /** @brief This slot tries to start tracking with the current device. If start tracking fails the user gets an error message and tracking stays off.*/
     void OnStartTracking();
 
-    /** @brief This slot stops tracking. If tracking is not strated it does nothing.*/
+    /** @brief This slot stops tracking. If tracking is not started it does nothing.*/
     void OnStopTracking();
 
     /** @brief This slot is called if the user wants to choose a file name for logging. A new windows to navigate through the file system and choose
@@ -125,7 +125,7 @@ class QmitkMITKIGTTrackingToolboxView : public QmitkAbstractView
         devices don't support auto detection.*/
     void OnAutoDetectTools();
 
-    /** @brief Slot for tracking timer. The timer updates the IGT pipline and also the logging filter if logging is activated.*/
+    /** @brief Slot for tracking timer. The timer updates the IGT pipeline and also the logging filter if logging is activated.*/
     void UpdateRenderTrackingTimer();
     void UpdateLoggingTrackingTimer();
 
@@ -211,7 +211,7 @@ class QmitkMITKIGTTrackingToolboxView : public QmitkAbstractView
    mitk::IGTLServer::Pointer m_IGTLServer;
    mitk::IGTLMessageProvider::Pointer m_IGTLMessageProvider;
 
-   /** @brief This timer updates the IGT pipline and also the logging filter if logging is activated.*/
+   /** @brief This timer updates the IGT pipeline and also the logging filter if logging is activated.*/
    QTimer* m_TrackingRenderTimer;
    QTimer* m_TrackingLoggingTimer;
    QTimer* m_TimeoutTimer;

--- a/Plugins/org.mitk.gui.qt.matchpoint.framereg/src/internal/QmitkMatchPointFrameCorrection.cpp
+++ b/Plugins/org.mitk.gui.qt.matchpoint.framereg/src/internal/QmitkMatchPointFrameCorrection.cpp
@@ -191,7 +191,7 @@ void QmitkMatchPointFrameCorrection::CreateQtPartControl(QWidget* parent)
   this->m_Controls.maskNodeSelector->SetDataStorage(this->GetDataStorage());
   this->m_Controls.maskNodeSelector->SetSelectionIsOptional(true);
 
-  this->m_Controls.imageNodeSelector->SetInvalidInfo("Select dymamic image.");
+  this->m_Controls.imageNodeSelector->SetInvalidInfo("Select dynamic image.");
   this->m_Controls.imageNodeSelector->SetPopUpTitel("Select dynamic image.");
   this->m_Controls.imageNodeSelector->SetPopUpHint("Select a dynamic image (time resolved) that should be frame corrected.");
   this->m_Controls.maskNodeSelector->SetInvalidInfo("Select target mask.");

--- a/Plugins/org.mitk.gui.qt.matchpoint.framereg/src/internal/QmitkMatchPointFrameCorrection.h
+++ b/Plugins/org.mitk.gui.qt.matchpoint.framereg/src/internal/QmitkMatchPointFrameCorrection.h
@@ -36,7 +36,7 @@ found in the LICENSE file.
 /*!
 \brief View for motion artefact correction of images.
 
-The view utalizes MatchPoint registration algorithms and the mitk::TimeFramesRegistrationHelper and implemnts the GUI
+The view utalizes MatchPoint registration algorithms and the mitk::TimeFramesRegistrationHelper and implements the GUI
 business logic to make frame correction aka motion artefact correction on 3D+t images.
 
 */

--- a/Plugins/org.mitk.gui.qt.matchpoint.mapper/src/internal/QmitkMatchPointMapper.cpp
+++ b/Plugins/org.mitk.gui.qt.matchpoint.mapper/src/internal/QmitkMatchPointMapper.cpp
@@ -457,7 +457,7 @@ void QmitkMatchPointMapper::SpawnMappingJob(bool doGeometryRefinement)
         pJob->m_spRegNode->SetData(mitk::GenerateIdentityRegistration3D().GetPointer());
         pJob->m_spRegNode->SetName("Auto_Generated_Identity_Transform");
         m_Controls.m_teLog->append(
-          QStringLiteral("<font color='gray'><i>No registration selected. Preforming mapping with identity transform</i></font>"));
+          QStringLiteral("<font color='gray'><i>No registration selected. Performing mapping with identity transform</i></font>"));
     }
 
     if (!doGeometryRefinement)

--- a/Plugins/org.mitk.gui.qt.matchpoint.visualizer/documentation/UserManual/map_view_visualizer_example.svg
+++ b/Plugins/org.mitk.gui.qt.matchpoint.visualizer/documentation/UserManual/map_view_visualizer_example.svg
@@ -326,7 +326,7 @@
        id="tspan9675-1"
        x="361.88541"
        y="202.52083"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:21.33333397px;font-family:Arial;-inkscape-font-specification:Arial;fill:#ff0000">(2) Registation information</tspan></text>
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:21.33333397px;font-family:Arial;-inkscape-font-specification:Arial;fill:#ff0000">(2) Registration information</tspan></text>
   <text
      xml:space="preserve"
      style="font-style:normal;font-weight:normal;font-size:40px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#ff0000;fill-opacity:1;stroke:none"

--- a/Plugins/org.mitk.gui.qt.matchpoint.visualizer/src/internal/QmitkMatchPointRegistrationVisualizer.ui
+++ b/Plugins/org.mitk.gui.qt.matchpoint.visualizer/src/internal/QmitkMatchPointRegistrationVisualizer.ui
@@ -813,7 +813,7 @@
           <string>FOV</string>
          </attribute>
          <attribute name="toolTip">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Field of view settings (FOV) for vizualizing the grid correctly (its origin, size and orientation).&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Field of view settings (FOV) for visualizing the grid correctly (its origin, size and orientation).&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
          </attribute>
          <layout class="QVBoxLayout" name="verticalLayout_4">
           <property name="spacing">

--- a/Plugins/org.mitk.gui.qt.mxnmultiwidgeteditor/documentation/UserManual/QmitkMxNMultiWidgetEditor.dox
+++ b/Plugins/org.mitk.gui.qt.mxnmultiwidgeteditor/documentation/UserManual/QmitkMxNMultiWidgetEditor.dox
@@ -35,7 +35,7 @@
 	<ul>
 		<li> Layout button: Choose a layout from presets or select a custom number of available window views and their layout in a grid
 		<li> Synchronization button: Enable or disable synchronized interaction across the window views
-		<li> Interaction mode button: Switch between the MITK interaction mouse mode and the PACS interation mouse mode
+		<li> Interaction mode button: Switch between the MITK interaction mouse mode and the PACS interaction mouse mode
 	</ul>
 
 \subsubsection org_mitk_editors_mxnmultiwidget_Layout MxN display layout
@@ -142,7 +142,7 @@
 	It can either be moved using the mouse or by using the appropriate mouse interaction (see above, e.g. mouse wheel scroling).
 
 \subsubsection org_mitk_editors_mxnmultiwidget_View_Direction View direction
-	Each window view "is looking in" one of the three avaiable view directions, namely "Axial", "Sagittal" or "Coronal".
+	Each window view "is looking in" one of the three available view directions, namely "Axial", "Sagittal" or "Coronal".
 	You can change the view direction by switching to another anatomical plane in the view direction drop down menu.
 	Changing the view direction will reset the camera to its default for the new view direction, meaning default zoom and
 	centered camera position.

--- a/Plugins/org.mitk.gui.qt.pointsetinteractionmultispectrum/src/internal/PointSetInteractionMultispectrum.cpp
+++ b/Plugins/org.mitk.gui.qt.pointsetinteractionmultispectrum/src/internal/PointSetInteractionMultispectrum.cpp
@@ -195,9 +195,9 @@ void PointSetInteractionMultispectrum::PlotReflectance(mitk::PointSet::Pointer m
   //    ////////////////  Qwt window configuration  /////////////////////////////////////////////
   delete m_Plot;
   m_Plot = new QwtPlot();                             // create a new plot               //
-  m_Plot->setAxisAutoScale(QwtPlot::xBottom);         // automatical scale -x            //
-  m_Plot->setAxisAutoScale(QwtPlot::yLeft);           // automatical scale -y            //
-  m_Plot->setTitle("Multispectral Reflectance");     // set the plot title              //
+  m_Plot->setAxisAutoScale(QwtPlot::xBottom);         // automatically scale -x          //
+  m_Plot->setAxisAutoScale(QwtPlot::yLeft);           // automatically scale -y          //
+  m_Plot->setTitle("Multispectral Reflectance");      // set the plot title              //
   m_Plot->setCanvasBackground(Qt::white);             // set the background color        //
   m_Plot->insertLegend(new QwtLegend());              // set the legend                  //
   QwtPlotGrid* grid = new QwtPlotGrid();              // set the grid                    //

--- a/Plugins/org.mitk.gui.qt.segmentation/documentation/UserManual/QmitkSegmentation.dox
+++ b/Plugins/org.mitk.gui.qt.segmentation/documentation/UserManual/QmitkSegmentation.dox
@@ -75,7 +75,7 @@ A label, as we used the term before, is already a single instance of itself but 
 
 If a label consists of multiple label instances, they each show their own distinct pixel value in square brackets as a clue for distinction and identification.
 
-It is important to understand that this number is not a separate, consequtive index for each label.
+It is important to understand that this number is not a separate, consecutive index for each label.
 It is just the plain pixel value of the label instance, which is unique across all label instances of the whole segmentation.
 
 \imageMacro{"QmitkSegmentation_LabelInstances.png","Label instances",10}
@@ -110,7 +110,7 @@ Note that renaming a label instance will make a separate label out of it, since 
 
 <b>Clear content</b> only clears the pixels of a label instance but won't delete the actual label instance.
 
-Groups can be <b>locked</b> and <b>unlocked</b> as a whole from their context menu, while label instances can be directly locked and unlocked outside the context menu as decribed further below.
+Groups can be <b>locked</b> and <b>unlocked</b> as a whole from their context menu, while label instances can be directly locked and unlocked outside the context menu as described further below.
 
 \section org_mitk_views_segmentationlabelsuggestions Label name and color suggestions
 

--- a/Plugins/org.mitk.gui.qt.segmentation/documentation/UserManual/QmitkSegmentationTaskList.dox
+++ b/Plugins/org.mitk.gui.qt.segmentation/documentation/UserManual/QmitkSegmentationTaskList.dox
@@ -24,7 +24,7 @@ The Segmentation Task List View shows the progress of the whole Segmentation Tas
 
 Below the progress indictator you can navigate between tasks, read their descriptions and related information, as well as load/activate the currently shown task.
 This will unload all data from a previously active task, if any, and load all data of the current task.
-To prevent any accidental data loss, unsaved task data will interfer task switches and you can decide on how to proceed.
+To prevent any accidental data loss, unsaved task data will interfere task switches and you can decide on how to proceed.
 
 Above the task description, the status of tasks is displayed as a pair of colored labels, indicating if a task is either active or inactive and if it is considered not to be done, having unsaved changes, or to be done.
 

--- a/Utilities/qtsingleapplication/qtlockedfile.cpp
+++ b/Utilities/qtsingleapplication/qtlockedfile.cpp
@@ -157,8 +157,8 @@ QtLockedFile::LockMode QtLockedFile::lockMode() const
     can be locked.
 
     If \a block is true, this function will block until the lock is
-    aquired. If \a block is false, this function returns \e false
-    immediately if the lock cannot be aquired.
+    acquired. If \a block is false, this function returns \e false
+    immediately if the lock cannot be acquired.
 
     If this object already has a lock of type \a mode, this function
     returns \e true immediately. If this object has a lock of a


### PR DESCRIPTION
Discovered in CMake/, Documentation/, Examples/, Plugins/, and Utilities/