### PR TITLE
Improve render windows utility widgets

### DIFF
--- a/Modules/QtWidgets/include/QmitkRenderWindowWidget.h
+++ b/Modules/QtWidgets/include/QmitkRenderWindowWidget.h
@@ -62,7 +62,8 @@ public:
   void RequestUpdate();
   void ForceImmediateUpdate();
 
-  void AddUtilityWidget(QWidget* utilityWidget);
+  enum UtilityWidgetPosition {Top, Bottom, Left, Right};
+  void AddUtilityWidget(QWidget* utilityWidget, UtilityWidgetPosition position = Top);
 
   void SetGradientBackgroundColors(const mitk::Color& upper, const mitk::Color& lower);
   void ShowGradientBackground(bool enable);
@@ -106,7 +107,8 @@ private:
   void ResetGeometry(const mitk::TimeGeometry* referenceGeometry);
 
   QString m_WidgetName;
-  QVBoxLayout* m_Layout;
+  QVBoxLayout* m_VerticalLayout;
+  QHBoxLayout* m_HorizontalLayout;
 
   mitk::DataStorage* m_DataStorage;
 

--- a/Modules/QtWidgets/src/QmitkRenderWindowWidget.cpp
+++ b/Modules/QtWidgets/src/QmitkRenderWindowWidget.cpp
@@ -71,15 +71,15 @@ void QmitkRenderWindowWidget::ForceImmediateUpdate()
 
 void QmitkRenderWindowWidget::AddUtilityWidget(QWidget* utilityWidget, UtilityWidgetPosition position)
 {
-    if (position == Top) {
-        m_VerticalLayout->insertWidget(0, utilityWidget);
-    } else if (position == Bottom) {
-        m_VerticalLayout->insertWidget(m_VerticalLayout->count(), utilityWidget);
-    } else if (position == Left) {
-        m_HorizontalLayout->insertWidget(0, utilityWidget);
-    } else if (position == Right) {
-        m_HorizontalLayout->insertWidget(m_HorizontalLayout->count(), utilityWidget);
-    }
+  if (position == Top) {
+    m_VerticalLayout->insertWidget(0, utilityWidget);
+  } else if (position == Bottom) {
+    m_VerticalLayout->insertWidget(-1, utilityWidget);
+  } else if (position == Left) {
+    m_HorizontalLayout->insertWidget(0, utilityWidget);
+  } else if (position == Right) {
+    m_HorizontalLayout->insertWidget(-1, utilityWidget);
+  }
 }
 
 void QmitkRenderWindowWidget::SetGradientBackgroundColors(const mitk::Color& upper, const mitk::Color& lower)

--- a/Modules/QtWidgets/src/QmitkRenderWindowWidget.cpp
+++ b/Modules/QtWidgets/src/QmitkRenderWindowWidget.cpp
@@ -69,9 +69,17 @@ void QmitkRenderWindowWidget::ForceImmediateUpdate()
   mitk::RenderingManager::GetInstance()->ForceImmediateUpdate(m_RenderWindow->renderWindow());
 }
 
-void QmitkRenderWindowWidget::AddUtilityWidget(QWidget* utilityWidget)
+void QmitkRenderWindowWidget::AddUtilityWidget(QWidget* utilityWidget, UtilityWidgetPosition position)
 {
-  m_Layout->insertWidget(0, utilityWidget);
+    if (position == Top) {
+        m_VerticalLayout->insertWidget(0, utilityWidget);
+    } else if (position == Bottom) {
+        m_VerticalLayout->insertWidget(m_VerticalLayout->count(), utilityWidget);
+    } else if (position == Left) {
+        m_HorizontalLayout->insertWidget(0, utilityWidget);
+    } else if (position == Right) {
+        m_HorizontalLayout->insertWidget(m_HorizontalLayout->count(), utilityWidget);
+    }
 }
 
 void QmitkRenderWindowWidget::SetGradientBackgroundColors(const mitk::Color& upper, const mitk::Color& lower)
@@ -179,11 +187,15 @@ void QmitkRenderWindowWidget::DisableCrosshair()
 
 void QmitkRenderWindowWidget::InitializeGUI()
 {
-  m_Layout = new QVBoxLayout(this);
-  m_Layout->setMargin(0);
-  setLayout(m_Layout);
+  m_VerticalLayout = new QVBoxLayout(this);
+  m_VerticalLayout->setMargin(0);
+  setLayout(m_VerticalLayout);
   setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
   setContentsMargins(0, 0, 0, 0);
+
+  m_HorizontalLayout = new QHBoxLayout(this);
+  m_HorizontalLayout->setMargin(0);
+  m_VerticalLayout->addItem(m_HorizontalLayout);
 
   if (nullptr == m_DataStorage)
   {
@@ -201,7 +213,7 @@ void QmitkRenderWindowWidget::InitializeGUI()
   auto* sliceNavigationController = this->GetSliceNavigationController();
   sliceNavigationController->SetDefaultViewDirection(mitk::AnatomicalPlane::Sagittal);
 
-  m_Layout->addWidget(m_RenderWindow);
+  m_HorizontalLayout->addWidget(m_RenderWindow);
 
   // set colors and corner annotation
   InitializeDecorations();


### PR DESCRIPTION
Added possibility to add utility widgets at all sides of a render window.

QmitkRenderWindowWidget originally offered a method to add a utility widget at the top of a render window only. But MITK-based applications want to add widgets also on bottom, left and right.

- Extended AddUtilityWidget() to add a widget at all sides of a render window.
- The interface is kept compatible.