### PR TITLE
T30289: Fix polhemus compilation issue

### DIFF
--- a/Modules/IGT/TrackingDevices/mitkPolhemusInterface.cpp
+++ b/Modules/IGT/TrackingDevices/mitkPolhemusInterface.cpp
@@ -40,7 +40,7 @@ bool mitk::PolhemusInterface::SetupDevice()
   m_pdiDev->SetPnoBuffer(MotionBuf, 0x1FA400);
   m_pdiDev->SetMetric(true); //use cm instead of inches
 
-  m_pdiDev->StartPipeExport();
+  //m_pdiDev->StartPipeExport();
 
   CPDImdat pdiMDat;
   pdiMDat.Empty();
@@ -94,13 +94,13 @@ bool mitk::PolhemusInterface::OpenConnection()
     switch (eType)
     {
     case PI_CNX_USB:
-      MITK_INFO << "USB Connection: " << m_pdiDev->GetLastResultStr();
+      MITK_INFO << "USB Connection";
       break;
     case PI_CNX_SERIAL:
-      MITK_INFO << "Serial Connection: " << m_pdiDev->GetLastResultStr();
+      MITK_INFO << "Serial Connection";
       break;
     default:
-      MITK_INFO << "DiscoverCnx result: " << m_pdiDev->GetLastResultStr();
+      MITK_INFO << "DiscoverCnx";
       break;
     }
 
@@ -185,7 +185,7 @@ bool mitk::PolhemusInterface::Disconnect()
   }
 
   returnValue = m_pdiDev->Disconnect();
-  MITK_INFO << "Disconnect: " << m_pdiDev->GetLastResultStr();
+  MITK_INFO << "Disconnect";
   return returnValue;
 }
 
@@ -217,7 +217,7 @@ std::vector<mitk::PolhemusInterface::trackingData> mitk::PolhemusInterface::GetL
   DWORD dwSize;
 
   //read one frame
-  if (!m_pdiDev->LastPnoPtr(pBuf, dwSize)) { MITK_WARN << m_pdiDev->GetLastResultStr(); }
+  if (!m_pdiDev->LastPnoPtr(pBuf, dwSize)) { MITK_WARN << "There is an issue"; }
 
   std::vector<mitk::PolhemusInterface::trackingData> returnValue = ParsePolhemusRawData(pBuf, dwSize);
 
@@ -241,7 +241,7 @@ std::vector<mitk::PolhemusInterface::trackingData> mitk::PolhemusInterface::GetS
 
   //read one frame
   if (!m_pdiDev->ReadSinglePnoBuf(pBuf, dwSize)) {
-    MITK_WARN << m_pdiDev->GetLastResultStr();
+    MITK_WARN << "There is an issue";
     return std::vector<mitk::PolhemusInterface::trackingData>();
   }
 

--- a/Modules/IGTUI/Qmitk/QmitkPolhemusTrackerWidget.cpp
+++ b/Modules/IGTUI/Qmitk/QmitkPolhemusTrackerWidget.cpp
@@ -193,18 +193,20 @@ void QmitkPolhemusTrackerWidget::on_m_ToggleToolTipCalibration_clicked()
   if (m_Controls->m_ToolSelection->currentIndex() != 0)
   {
     mitk::PolhemusTool* _tool = dynamic_cast<mitk::PolhemusTool*> (this->m_TrackingDevice->GetToolByName(m_Controls->m_ToolSelection->currentText().toStdString()));
-    mitk::Point3D tip = _tool->GetToolTipPosition().GetVectorFromOrigin()*(-1.);
+    auto tip = _tool->GetToolTipPosition().GetVectorFromOrigin()*(-1.);
+    auto tipPoint = mitk::Point3D(tip);
     mitk::Quaternion quat = _tool->GetToolAxisOrientation().inverse();
-    _tool->SetToolTipPosition(tip, quat);
+    _tool->SetToolTipPosition(tipPoint, quat);
   }
   else
   {
     for (int i = 0; i < m_TrackingDevice->GetToolCount(); ++i)
     {
       mitk::PolhemusTool* _tool = dynamic_cast<mitk::PolhemusTool*> (this->m_TrackingDevice->GetTool(i));
-      mitk::Point3D tip = _tool->GetToolTipPosition().GetVectorFromOrigin()*(-1.);
+      auto tip = _tool->GetToolTipPosition().GetVectorFromOrigin()*(-1.);
+      auto tipPoint = mitk::Point3D(tip);
       mitk::Quaternion quat = _tool->GetToolAxisOrientation().inverse();
-      _tool->SetToolTipPosition(tip, quat);
+      _tool->SetToolTipPosition(tipPoint, quat);
     }
   }
 }


### PR DESCRIPTION
`Modules\IGT\TrackingDevices\mitkPolhemusInterface.cpp` uses `m_pdiDev->GetLastResultStr()` which leads to compiler issues, failing the whole build process.
As a quick fix, we suggest removing these calls, as they are only used for verbose logging information.

We also update the use of the ITK library to work with the new version in the upcoming release.

@Alfred-Franz 