### PR TITLE
Upgrade DCMQI to 1.3.1 - performance improvements and merged segments support

### DIFF
--- a/CMakeExternals/DCMQI.cmake
+++ b/CMakeExternals/DCMQI.cmake
@@ -31,7 +31,7 @@ if(MITK_USE_DCMQI)
     ExternalProject_Add(${proj}
       LIST_SEPARATOR ${sep}
       GIT_REPOSITORY https://github.com/QIICR/dcmqi.git
-      GIT_TAG v1.2.5
+      GIT_TAG v1.3.0
       UPDATE_COMMAND ""
       INSTALL_COMMAND ""
       CMAKE_GENERATOR ${gen}

--- a/CMakeExternals/DCMQI.cmake
+++ b/CMakeExternals/DCMQI.cmake
@@ -31,7 +31,7 @@ if(MITK_USE_DCMQI)
     ExternalProject_Add(${proj}
       LIST_SEPARATOR ${sep}
       GIT_REPOSITORY https://github.com/QIICR/dcmqi.git
-      GIT_TAG v1.3.0
+      GIT_TAG v1.3.1
       UPDATE_COMMAND ""
       INSTALL_COMMAND ""
       CMAKE_GENERATOR ${gen}


### PR DESCRIPTION
There are two very important improvements in this updated version:

1. Performance of conversion is improved perhaps by at least an order of magnitude, cutting down the conversion for large DICOM SEG (such as TotalSegmentator results) from minutes to seconds.
2. It is now possible to save non-overlapping segments into a single file instead of previous convention of saving each segment as a separate file. See details in https://github.com/QIICR/dcmqi/pull/464. Note that to use this feature you will need to use the `--mergeSegments` flag (https://github.com/QIICR/dcmqi/blob/master/apps/seg/segimage2itkimage.xml#L69-L76). There may be changes needed to the MITK dcmqi wrapper - I am sure you will test this - but there are no changes to the JSON schema.