### PR TITLE
Fix moving items in data manager

### DIFF
--- a/Modules/QtWidgets/src/QmitkDataStorageTreeModel.cpp
+++ b/Modules/QtWidgets/src/QmitkDataStorageTreeModel.cpp
@@ -287,7 +287,14 @@ bool QmitkDataStorageTreeModel::dropMimeData(
       }
       else
       {
-        this->beginInsertRows(parentModelIndex, dropIndex, dropIndex + listOfItemsToDrop.size() - 1);
+        if (row == -1) // drag onto a node, insert in the parents child list
+        {
+          this->beginInsertRows(parentModelIndex, dropIndex, dropIndex + listOfItemsToDrop.size() - 1);
+        }
+        else // drag between nodes (i.e. onto the parent of these nodes), insert in the dropped item's child list which *is* the parent of these nodes
+        {
+          this->beginInsertRows(dropItemModelIndex, dropIndex, dropIndex + listOfItemsToDrop.size() - 1);
+        }
       }
 
       for (diIter = listOfItemsToDrop.begin(); diIter != listOfItemsToDrop.end(); diIter++)


### PR DESCRIPTION
When moving a node item in the data manager tree view and dropping it **in between** two items, not the parent of that two items was used as dropping destination but the grand parent.