### PR TITLE
Fix typos in various directories

### DIFF
--- a/Documentation/Doxygen/3-DeveloperManual/Concepts/Exceptions.dox
+++ b/Documentation/Doxygen/3-DeveloperManual/Concepts/Exceptions.dox
@@ -47,7 +47,7 @@ class myExampleClass
   }
 \endverbatim
 
-In general, exceptions emit no logging messages by default because they are intended to be catched by overlying classes. This classes should then decide what to do, e.g. to log an error message or handle the exception in another way. See the logging documentation for more details on error logging.
+In general, exceptions emit no logging messages by default because they are intended to be caught by overlying classes. This classes should then decide what to do, e.g. to log an error message or handle the exception in another way. See the logging documentation for more details on error logging.
 
 \subsection Catch Catching exceptions
 

--- a/Documentation/Doxygen/3-DeveloperManual/Concepts/MITKROIs.md
+++ b/Documentation/Doxygen/3-DeveloperManual/Concepts/MITKROIs.md
@@ -17,7 +17,7 @@ A few of these properties are used by MITK to define the appearance of a rendere
 
   - "color" (mitk::ColorProperty): Color/RGB triplet of the rendered ROI (default: white \[1.0, 1.0, 1.0\])
   - "opacity" (mitk::FloatProperty): Opacity of the rendered ROI (default: 100% \[1.0\])
-  - "lineWidth" (mitk::FloatProperty): Line width of the egdes of the rendered ROI (default: 1px \[1.0\])
+  - "lineWidth" (mitk::FloatProperty): Line width of the edges of the rendered ROI (default: 1px \[1.0\])
 
 ROIs can be optionally time-resolved and define both coordinates and properties per time step, allowing for a dynamic appearance, position, and size over time.
 
@@ -187,4 +187,4 @@ Further hints:
   - The column vectors of the rotation matrix represent the three space directions.
   - The norms of the space directions are equivalent to the spacing values.
   - The rightmost column vector is always `[0, 0, 0, 1]`.
-  - The bottom row vector corresonds to the origin (with 1 as fourth element).
+  - The bottom row vector corresponds to the origin (with 1 as fourth element).

--- a/Examples/Plugins/org.mitk.example.gui.extensionpointcontribution/documentation/doxygen/modules.dox
+++ b/Examples/Plugins/org.mitk.example.gui.extensionpointcontribution/documentation/doxygen/modules.dox
@@ -2,7 +2,7 @@
   \defgroup org_mitk_example_gui_extensionpointcontribution org.mitk.example.gui.extensionpointcontribution
   \ingroup MITKExamplePlugins
 
-  \brief A minimal applictaion that contributes an extension to an extension point.
+  \brief A minimal application that contributes an extension to an extension point.
 */
 
 /**

--- a/Examples/Plugins/org.mitk.example.gui.extensionpointdefinition/documentation/doxygen/modules.dox
+++ b/Examples/Plugins/org.mitk.example.gui.extensionpointdefinition/documentation/doxygen/modules.dox
@@ -2,7 +2,7 @@
   \defgroup org_mitk_example_gui_extensionpointdefinition org.mitk.example.gui.extensionpointdefinition
   \ingroup MITKExamplePlugins
 
-  \brief A minimal applictaion that defines an extension point and collects extensions.
+  \brief A minimal application that defines an extension point and collects extensions.
 */
 
 /**

--- a/Examples/Plugins/org.mitk.example.gui.minimalapplication/documentation/doxygen/modules.dox
+++ b/Examples/Plugins/org.mitk.example.gui.minimalapplication/documentation/doxygen/modules.dox
@@ -2,7 +2,7 @@
   \defgroup org_mitk_example_gui_minimalapplication org.mitk.example.gui.minimalapplication
   \ingroup MITKExamplePlugins
 
-  \brief A minimal applictaion plug-in.
+  \brief A minimal application plug-in.
 */
 
 /**

--- a/Examples/Plugins/org.mitk.example.gui.selectionservicemitk.views/src/internal/SelectionViewMitk.cpp
+++ b/Examples/Plugins/org.mitk.example.gui.selectionservicemitk.views/src/internal/SelectionViewMitk.cpp
@@ -41,7 +41,7 @@ void SelectionViewMitk::CreateQtPartControl(QWidget *parent)
   QListWidgetItem *listItemDataNode1 = new QListWidgetItem(QString::fromStdString(dataNode1->GetName()));
   QListWidgetItem *listItemDataNode2 = new QListWidgetItem(QString::fromStdString(dataNode2->GetName()));
 
-  // set the data of created QListWidgetItems two the informations of the data nodes
+  // set the data of created QListWidgetItems too the information of the data nodes
   listItemDataNode1->setData(QmitkDataNodeRole, QVariant::fromValue(dataNode1));
   listItemDataNode2->setData(QmitkDataNodeRole, QVariant::fromValue(dataNode2));
 

--- a/Modules/AppUtil/src/mitkBaseApplication.cpp
+++ b/Modules/AppUtil/src/mitkBaseApplication.cpp
@@ -592,7 +592,7 @@ namespace mitk
     {
       // If not set explicitly otherwise, prefer xcb as platform on Linux, as we had issues
       // with wayland in combination with VTK and GLEW. Note that the shell scripts for
-      // excutables in our installers also set the platform to xcb.
+      // executables in our installers also set the platform to xcb.
       if (qEnvironmentVariableIsEmpty("QT_QPA_PLATFORM"))
         qputenv("QT_QPA_PLATFORM", "xcb");
     }

--- a/Modules/BasicImageProcessing/documentation/UserManual/mitkBasicImageProcessingMiniAppsPortalPage.dox
+++ b/Modules/BasicImageProcessing/documentation/UserManual/mitkBasicImageProcessingMiniAppsPortalPage.dox
@@ -3,7 +3,7 @@
 
 \tableofcontents
 
-The Basic Image Processing Mini Apps bundle the functionality that is commonly needed for the processing of medical images. As all other MiniApps, they follow the <a href="https://www.slicer.org/slicerWiki/index.php/Slicer3:Execution_Model_Documentation">Slicer Execution Model</a> in describing themselves via xml. You can simply obtain a description by calling the MiniApp without any parameter. If the MiniApp is calles with the option "--xml" a XML description of all possible parameter is added.
+The Basic Image Processing Mini Apps bundle the functionality that is commonly needed for the processing of medical images. As all other MiniApps, they follow the <a href="https://www.slicer.org/slicerWiki/index.php/Slicer3:Execution_Model_Documentation">Slicer Execution Model</a> in describing themselves via xml. You can simply obtain a description by calling the MiniApp without any parameter. If the MiniApp is called with the option "--xml" a XML description of all possible parameter is added.
 
 \section bipmasec1 Description of Mini Apps
 
@@ -35,7 +35,7 @@ Calculate a Multi-Resolution Pyramid of the given image. The resolution is reduc
 Resample a mask to a new spacing
 
 \subsection bipmasub10 mitkResampleMask
-Similar to mitkResampleImage, but specificly tailored to resampling a mask.
+Similar to mitkResampleImage, but specifically tailored to resampling a mask.
 
 \subsection bipmasub11 mitkSingleImageArithmetic
 Applies single operand mathematical operations to each voxel of an image

--- a/Modules/Chart/Test/mitkChartExampleTest.cpp
+++ b/Modules/Chart/Test/mitkChartExampleTest.cpp
@@ -185,7 +185,7 @@ public:
     {
         MITK_INFO << "=== ClearData";
 
-        // Claering data
+        // Clearing data
         mitk::ChartExampleTestHelper helper;
         helper.qmitkChartWidget.Clear();
         //int size = helper.qmitkChartWidget.ReturnSizeOfMemory();

--- a/Modules/Chart/resource/Chart.js
+++ b/Modules/Chart/resource/Chart.js
@@ -260,7 +260,7 @@ window.onload = function()
  * Inits the height of the chart element to 90% of the full window height.
  */
 function initHeight() {
-  var size = window.innerHeight-(window.innerHeight/100*5); //subtract 10% of height to hide vertical scrool bar
+  var size = window.innerHeight-(window.innerHeight/100*5); //subtract 10% of height to hide vertical scroll bar
   let chart = document.getElementById("chart");
   chart.style.height = `${size}px`;
 }

--- a/Modules/Classification/CLCore/include/mitkAbstractGlobalImageFeature.h
+++ b/Modules/Classification/CLCore/include/mitkAbstractGlobalImageFeature.h
@@ -55,7 +55,7 @@ namespace mitk
     bool operator ==(const FeatureID& rh) const;
   };
 
-  /**Helper that takes a pass templateID clones it and populates it with the also passed informations before returning it.
+  /**Helper that takes a pass templateID clones it and populates it with the also passed information before returning it.
    * @param templateID reference ID that should be cloned.
    * @param name Name of the feature.*/
   MITKCLCORE_EXPORT FeatureID CreateFeatureID(FeatureID templateID, std::string name);

--- a/Modules/Classification/CLUtilities/include/itkEnhancedHistogramToTextureFeaturesFilter.h
+++ b/Modules/Classification/CLUtilities/include/itkEnhancedHistogramToTextureFeaturesFilter.h
@@ -72,7 +72,7 @@ namespace itk
     * features 1, 2, 4, 5, 6, and 7. There is some correlation between the various
     * features, so using all of them at the same time is not necessarialy a good idea.
     *
-    * NOTA BENE: The input histogram will be forcably normalized!
+    * NOTA BENE: The input histogram will be forcibly normalized!
     * This algorithm takes three passes through the input
     * histogram if the histogram was already normalized, and four if not.
     *

--- a/Modules/Classification/CLUtilities/include/itkEnhancedScalarImageToNeighbourhoodGreyLevelDifferenceMatrixFilter.h
+++ b/Modules/Classification/CLUtilities/include/itkEnhancedScalarImageToNeighbourhoodGreyLevelDifferenceMatrixFilter.h
@@ -41,7 +41,7 @@ namespace itk
   {
     /** \class EnhancedScalarImageToNeighbourhoodGreyLevelDifferenceMatrixFilter
     *  \brief This class computes a run length matrix (histogram) from
-    *  a given image and a mask image if provided. Run length matrces are
+    *  a given image and a mask image if provided. Run length matrices are
     *  used for image texture description.
     *
     * This filters creates a grey-level run length matrix from a N-D scalar

--- a/Modules/Classification/CLUtilities/include/itkEnhancedScalarImageToRunLengthMatrixFilter.h
+++ b/Modules/Classification/CLUtilities/include/itkEnhancedScalarImageToRunLengthMatrixFilter.h
@@ -41,7 +41,7 @@ namespace itk
   {
     /** \class EnhancedScalarImageToRunLengthMatrixFilter
     *  \brief This class computes a run length matrix (histogram) from
-    *  a given image and a mask image if provided. Run length matrces are
+    *  a given image and a mask image if provided. Run length matrices are
     *  used for image texture description.
     *
     * This filters creates a grey-level run length matrix from a N-D scalar

--- a/Modules/Classification/CLUtilities/include/itkEnhancedScalarImageToSizeZoneMatrixFilter.h
+++ b/Modules/Classification/CLUtilities/include/itkEnhancedScalarImageToSizeZoneMatrixFilter.h
@@ -41,7 +41,7 @@ namespace itk
   {
     /** \class EnhancedScalarImageToSizeZoneMatrixFilter
     *  \brief This class computes a run length matrix (histogram) from
-    *  a given image and a mask image if provided. Run length matrces are
+    *  a given image and a mask image if provided. Run length matrices are
     *  used for image texture description.
     *
     * This filters creates a grey-level run length matrix from a N-D scalar

--- a/Modules/Classification/CLUtilities/include/mitkGIFIntensityVolumeHistogramFeatures.h
+++ b/Modules/Classification/CLUtilities/include/mitkGIFIntensityVolumeHistogramFeatures.h
@@ -26,7 +26,7 @@ namespace mitk
   * it. It is based on the intensity-volume histogram (IVH) which describes the relation between the
   * grey level index i (and the corresponding intensity \f$x_i\f$) and the volume fraction \f$f\f$ that
   * with an intensity that is equal or greater than \f$x_i\f$. This feature is original proposed in
-  * El Naqa et al. Exploring feature-based approaches in PET images for prediciting cancer treatment outcomes.
+  * El Naqa et al. Exploring feature-based approaches in PET images for predicting cancer treatment outcomes.
   * Pattern recognition 2009.
   *
   * This feature calculator is activated by the option "<b>-intensity-volume-histogram</b>" or "<b>-ivoh</b>".

--- a/Modules/Classification/CLUtilities/src/MiniAppUtils/mitkGlobalImageFeaturesParameter.cpp
+++ b/Modules/Classification/CLUtilities/src/MiniAppUtils/mitkGlobalImageFeaturesParameter.cpp
@@ -73,7 +73,7 @@ void mitk::cl::GlobalImageFeaturesParameter::ParseFileLocations(std::map<std::st
 {
 
   //
-  // Read input and output file informations
+  // Read input and output file information
   //
   imagePath = parsedArgs["image"].ToString();
   maskPath = parsedArgs["mask"].ToString();
@@ -103,7 +103,7 @@ void mitk::cl::GlobalImageFeaturesParameter::ParseAdditionalOutputs(std::map<std
 {
 
   //
-  // Read input and output file informations
+  // Read input and output file information
   //
   useLogfile = false;
   if (parsedArgs.count("logfile"))

--- a/Modules/CommandLine/include/mitkCommandLineParser.h
+++ b/Modules/CommandLine/include/mitkCommandLineParser.h
@@ -233,7 +233,7 @@ public:
  * <code>errorString()</code> can be used the get the last error description.
  *
  * @param argument The previously added long or short argument name.
- * @param expression A regular expression which the arugment parameters must match.
+ * @param expression A regular expression which the argument parameters must match.
  * @param exactMatchFailedMessage An error message explaining why the parameter did
  *        not match.
  *

--- a/Modules/CommandLine/src/mitkCommandLineParser.cpp
+++ b/Modules/CommandLine/src/mitkCommandLineParser.cpp
@@ -577,7 +577,7 @@ map<string, us::Any> mitkCommandLineParser::parseArguments(const StringContainer
       {
         if (this->Internal->Debug)
         {
-          std::cout << "  Proccessing StringList ...";
+          std::cout << "  Processing StringList ...";
         }
         int j = 1;
         while (j + i < arguments.size())

--- a/Modules/ContourModel/Algorithms/mitkContourModelSubDivisionFilter.cpp
+++ b/Modules/ContourModel/Algorithms/mitkContourModelSubDivisionFilter.cpp
@@ -81,7 +81,7 @@ void mitk::ContourModelSubDivisionFilter::GenerateData()
         auto first = contour->IteratorBegin();
         auto last = contour->IteratorEnd() - 1;
 
-        // tempory contour to store result of a subdivision iteration
+        // temporary contour to store result of a subdivision iteration
         mitk::ContourModel::Pointer tempContour = mitk::ContourModel::New();
 
         // insert subpoints

--- a/Modules/ContourModel/DataManagement/mitkContourElement.h
+++ b/Modules/ContourModel/DataManagement/mitkContourElement.h
@@ -21,7 +21,7 @@ found in the LICENSE file.
 namespace mitk
 {
   /** \brief Represents a contour in 3D space.
-  A ContourElement is consisting of linked vertices implicitely defining the contour.
+  A ContourElement is consisting of linked vertices implicitly defining the contour.
   They are stored in a double ended queue making it possible to add vertices at front and
   end of the contour and to iterate in both directions.
   To mark a vertex as a special one it can be set as a control point.

--- a/Modules/ContourModel/DataManagement/mitkContourModel.h
+++ b/Modules/ContourModel/DataManagement/mitkContourModel.h
@@ -292,7 +292,7 @@ namespace mitk
                             mitk::ContourElement::VertexType *previousVertex = nullptr,
                             mitk::ContourElement::VertexType *nextVertex = nullptr);
 
-    /**Overloaded version that returns additional information (start and end vertix of the line
+    /**Overloaded version that returns additional information (start and end vertex of the line
     closest to the passed point and the closest point on the contour).
     @remark segmentStart, segmentStop and closestContourPoint are only valid if the function returns true.
     */
@@ -340,13 +340,13 @@ namespace mitk
 
     /** \brief Remove a vertex at given index within the container.
 
-    @return true = the vertex was successfuly removed;  false = wrong index.
+    @return true = the vertex was successfully removed;  false = wrong index.
     */
     bool RemoveVertexAt(int index, TimeStepType timestep = 0);
 
     /** \brief Remove a vertex at given timestep within the container.
 
-    @return true = the vertex was successfuly removed.
+    @return true = the vertex was successfully removed.
     */
     bool RemoveVertex(const VertexType *vertex, TimeStepType timestep = 0);
 
@@ -356,7 +356,7 @@ namespace mitk
     Note that possibly no vertex at this position and eps is stored inside
     the contour.
 
-    @return true = the vertex was successfuly removed;  false = no vertex found.
+    @return true = the vertex was successfully removed;  false = no vertex found.
     */
     bool RemoveVertexAt(Point3D &point, float eps, TimeStepType timestep = 0);
 

--- a/Modules/Core/include/mitkIOUtil.h
+++ b/Modules/Core/include/mitkIOUtil.h
@@ -118,9 +118,9 @@ namespace mitk
     static std::string GetTempPath();
 
     /**
-    * Returns the Directory Seperator for the current OS.
+    * Returns the Directory Separator for the current OS.
     *
-    * @return the Directory Seperator for the current OS, i.e. "\\" for Windows and "/" otherwise.
+    * @return the Directory Separator for the current OS, i.e. "\\" for Windows and "/" otherwise.
     */
     static char GetDirectorySeparator();
 

--- a/Modules/Core/include/mitkPropertyList.h
+++ b/Modules/Core/include/mitkPropertyList.h
@@ -229,7 +229,7 @@ namespace mitk
     /**
      * @brief Serialize the property list to JSON.
      *
-     * @note Properties of a certain type can only be deseralized again if their type has been
+     * @note Properties of a certain type can only be deserialized again if their type has been
      * registered via the IPropertyDeserialization core service.
      *
      * @sa CoreServices
@@ -240,7 +240,7 @@ namespace mitk
     /**
      * @brief Deserialize the property list from JSON.
      *
-     * @note Properties of a certain type can only be deseralized again if their type has been
+     * @note Properties of a certain type can only be deserialized again if their type has been
      * registered via the IPropertyDeserialization core service.
      *
      * @sa CoreServices

--- a/Modules/Core/src/DataManagement/mitkBaseGeometry.cpp
+++ b/Modules/Core/src/DataManagement/mitkBaseGeometry.cpp
@@ -269,7 +269,7 @@ mitk::Point3D mitk::BaseGeometry::GetCenter() const
   Point3D c = m_BoundingBox->GetCenter();
   if (m_ImageGeometry)
   {
-    // Get Center returns the middel of min and max pixel index. In corner based images, this is the right position.
+    // Get Center returns the middle of min and max pixel index. In corner based images, this is the right position.
     // In center based images (imageGeometry == true), the index needs to be shifted back.
     c[0] -= 0.5;
     c[1] -= 0.5;

--- a/Modules/Core/test/mitkDispatcherTest.cpp
+++ b/Modules/Core/test/mitkDispatcherTest.cpp
@@ -138,7 +138,7 @@ public:
     // New DataNode and new interactor, this should result in additional Interactor in the Dispatcher.
     m_Ei2->SetDataNode(m_Dn);
 
-    CPPUNIT_ASSERT_MESSAGE("06 Exprected number of registered Interactors is 2",
+    CPPUNIT_ASSERT_MESSAGE("06 Expected number of registered Interactors is 2",
                        m_Renderer->GetDispatcher()->GetNumberOfInteractors() == 2);
   }
 

--- a/Modules/Core/test/mitkLevelWindowManagerTest.cpp
+++ b/Modules/Core/test/mitkLevelWindowManagerTest.cpp
@@ -263,7 +263,7 @@ public:
     CPPUNIT_ASSERT_MESSAGE("\"imageForLevelWindow\" property not correctly set", AssertImageForLevelWindowProperty(false, false, true));
     CPPUNIT_ASSERT_MESSAGE("\"levelwindow\" property not correctly set", AssertLevelWindowProperty(false, false, true));
 
-    // The top level node will alsways be used as a fall back node
+    // The top level node will always be used as a fall back node
     // if no specific mode is selected.
     m_DataNode3->SetBoolProperty("imageForLevelWindow", false);
     CPPUNIT_ASSERT_MESSAGE("\"imageForLevelWindow\" property not correctly set", AssertImageForLevelWindowProperty(false, false, true));

--- a/Modules/CppMicroServices/third_party/dirent_win32.h
+++ b/Modules/CppMicroServices/third_party/dirent_win32.h
@@ -285,7 +285,7 @@ static struct dirent *readdir(DIR *dirp)
          return nullptr;
       }
       if (FindNextFileA (dirp->search_handle, &dirp->find_data) == FALSE) {
-         /* the very last entry has been processed or an error occured */
+         /* the very last entry has been processed or an error occurred */
          FindClose (dirp->search_handle);
          dirp->search_handle = INVALID_HANDLE_VALUE;
          return nullptr;

--- a/Modules/DICOM/include/mitkDICOMReaderConfigurator.h
+++ b/Modules/DICOM/include/mitkDICOMReaderConfigurator.h
@@ -70,7 +70,7 @@ namespace mitk
   and afterwards the images within each group are sorted by means of DICOMSortCriterion, which
   most commonly mentions a tag.
 
-  Tag element and group are interpreted as the exadecimal numbers
+  Tag element and group are interpreted as the hexadecimal numbers
   found all around the DICOM standard. The numbers can be prepended by a "0x" if this is preferred
   by the programmer (but they are taken as hexadecimal in all cases).
 

--- a/Modules/DICOM/resource/configurations/3D/imageposition_byacquisition.xml
+++ b/Modules/DICOM/resource/configurations/3D/imageposition_byacquisition.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" standalone="no"?>
 <DICOMFileReader
   label="Image Position by Acquisition"
-  description="Group images by Acquistion, then sort groups by Image Position (Patient)"
+  description="Group images by Acquisition, then sort groups by Image Position (Patient)"
   class="DICOMITKSeriesGDCMReader"
   version="2"
   fixTiltByShearing="true">

--- a/Modules/DICOMPM/autoload/DICOMPMIO/mitkDICOMPMIO.cpp
+++ b/Modules/DICOMPM/autoload/DICOMPMIO/mitkDICOMPMIO.cpp
@@ -88,7 +88,7 @@ namespace mitk
 
     try
     {
-      // Generate dcmdataset witk DICOM tags from property list; ATM the source are the filepaths from the
+      // Generate dcmdataset with DICOM tags from property list; ATM the source are the filepaths from the
       // property list
       mitk::StringLookupTableProperty::Pointer filesProp =
         dynamic_cast<mitk::StringLookupTableProperty *>(PMinput->GetProperty("referenceFiles").GetPointer());

--- a/Modules/GraphAlgorithms/itkShortestPathCostFunctionLiveWire.h
+++ b/Modules/GraphAlgorithms/itkShortestPathCostFunctionLiveWire.h
@@ -20,7 +20,7 @@ found in the LICENSE file.
 namespace itk
 {
   /** \brief Cost function for LiveWire purposes.
-  Specific features are considered to calculate cummulative
+  Specific features are considered to calculate cumulative
   costs of a link between two pixels. These are:
 
   - Gradient Magnitude

--- a/Modules/GraphAlgorithms/itkShortestPathCostFunctionLiveWire.txx
+++ b/Modules/GraphAlgorithms/itkShortestPathCostFunctionLiveWire.txx
@@ -267,7 +267,7 @@ namespace itk
     }
     costs = w1 * laplacianCost + w2 * gradientCost + w3 * gradientDirectionCost;
 
-    // scale by euclidian distance
+    // scale by euclidean distance
     double costScale;
     if (p1[0] == p2[0] || p1[1] == p2[1])
     {
@@ -338,7 +338,7 @@ namespace itk
 
       // m_EdgeImage = zeroCrossingImageFilter->GetOutput();
 
-      // cast image to float to apply canny edge dection filter
+      // cast image to float to apply canny edge detection filter
       /*typedef itk::CastImageFilter< TInputImageType, FloatImageType > CastFilterType;
       CastFilterType::Pointer castFilter = CastFilterType::New();
       castFilter->SetInput(this->m_Image);*/
@@ -364,7 +364,7 @@ namespace itk
       m_EdgeImage = cannyEdgeDetectionfilter->GetOutput();
 
       // set minCosts
-      m_MinCosts = 0.0; // The lower, the more thouroughly! 0 = dijkstra. If estimate costs are lower than actual costs
+      m_MinCosts = 0.0; // The lower, the more thoroughly! 0 = dijkstra. If estimate costs are lower than actual costs
                       // everything is fine. If estimation is higher than actual costs, you might not get the shortest
                       // but a different path.
 

--- a/Modules/GraphAlgorithms/itkShortestPathImageFilter.h
+++ b/Modules/GraphAlgorithms/itkShortestPathImageFilter.h
@@ -28,7 +28,7 @@ found in the LICENSE file.
 // void SetActivateTimeOut(bool) // Optional (default=false), for debug issues: after 30s algorithms terminates. You can
 // have a look at the VectorOrderImage to see how far it came
 // void SetMakeOutputImage(bool) // Optional (default=true), Generate an outputimage of the path. You can also get the
-// path directoy with GetVectorPath()
+// path directory with GetVectorPath()
 // void SetCalcAllDistances(bool) // Optional (default=false), Calculate Distances over the whole image. CAREFUL,
 // algorithm time extends a lot. Necessary for GetDistanceImage
 // void SetStoreVectorOrder(bool) // Optional (default=false), Stores in which order the pixels were checked. Necessary
@@ -44,7 +44,7 @@ found in the LICENSE file.
 // GetVectorOrderIMage // Returns the Vector Order image
 //
 // EXAMPLE USE
-// pleae see qmitkmitralvalvesegmentation4dtee bundle
+// please see qmitkmitralvalvesegmentation4dtee bundle
 
 namespace itk
 {

--- a/Modules/ImageStatisticsUI/Qmitk/QmitkDataGeneratorBase.h
+++ b/Modules/ImageStatisticsUI/Qmitk/QmitkDataGeneratorBase.h
@@ -36,7 +36,7 @@ how to remove obsolete data from the storage, the base class takes care of the o
 and orchestrates the whole checking and generation workflow.
 In all the generation/orchestration process the data storage, passed to the generator, 1) serves as place where the final
 results are stored and searched and 2) it resembles the state of the generation process with these final results and WIP
-place holder nodes that indicate planed or currently processed generation steps.
+place holder nodes that indicate planned or currently processed generation steps.
 */
 class MITKIMAGESTATISTICSUI_EXPORT QmitkDataGeneratorBase : public QObject
 {

--- a/Modules/MapperExt/include/mitkUnstructuredGridMapper2D.h
+++ b/Modules/MapperExt/include/mitkUnstructuredGridMapper2D.h
@@ -49,7 +49,7 @@ namespace mitk
     itkCloneMacro(Self);
 
       /**
-       * Renders a cut through a pointset by cutting trough the n-cells,
+       * Renders a cut through a pointset by cutting through the n-cells,
        * producing (n-1)-cells.
        * @param renderer the render to render in.
        */

--- a/Modules/MapperExt/src/mitkSplineVtkMapper3D.cpp
+++ b/Modules/MapperExt/src/mitkSplineVtkMapper3D.cpp
@@ -118,7 +118,7 @@ void mitk::SplineVtkMapper3D::ApplyAllProperties(BaseRenderer *renderer, vtkActo
   rgba[1] = temprgba[1];
   rgba[2] = temprgba[2];
   rgba[3] = temprgba[3];
-  // finaly set the color inside the actor
+  // finally set the color inside the actor
   m_SplinesActor->GetProperty()->SetColor(rgba);
 
   float lineWidth;

--- a/Modules/MapperExt/src/vtkPointSetSlicer.cxx
+++ b/Modules/MapperExt/src/vtkPointSetSlicer.cxx
@@ -110,7 +110,7 @@ int vtkPointSetSlicer::RequestData(vtkInformation * /*request*/,
   vtkInformation *inInfo = inputVector[0]->GetInformationObject(0);
   vtkInformation *outInfo = outputVector->GetInformationObject(0);
 
-  // get the input and ouptut
+  // get the input and output
   vtkDataSet *input = vtkDataSet::SafeDownCast(inInfo->Get(vtkDataObject::DATA_OBJECT()));
   vtkPolyData *output = vtkPolyData::SafeDownCast(outInfo->Get(vtkDataObject::DATA_OBJECT()));
 

--- a/Modules/MatchPointRegistration/include/mitkMAPRegistrationWrapper.h
+++ b/Modules/MatchPointRegistration/include/mitkMAPRegistrationWrapper.h
@@ -167,7 +167,7 @@ public:
   };
 
   /*! Helper function that maps a mitk point (of arbitrary dimension) from target space to moving space
-  @remarks The operation might faile, if the moving and target dimension of the registration
+  @remarks The operation might fail, if the moving and target dimension of the registration
   is not equal to the dimensionalities of the passed points.
   @pre valid registration instance must be set.
   @param inPoint pointer to a TargetPointType

--- a/Modules/MatchPointRegistration/include/mitkRegEvaluationMapper2D.h
+++ b/Modules/MatchPointRegistration/include/mitkRegEvaluationMapper2D.h
@@ -158,7 +158,7 @@ protected:
     */
   void TransformActor(mitk::BaseRenderer* renderer);
 
-  /** \brief Generates a plane according to the size of the resliced image in milimeters.
+  /** \brief Generates a plane according to the size of the resliced image in millimeters.
     *
     * In VTK a vtkPlaneSource is defined through three points. The origin and two
     * points defining the axes of the plane (see VTK documentation). The origin is

--- a/Modules/MatchPointRegistration/include/mitkRegistrationWrapperMapperBase.h
+++ b/Modules/MatchPointRegistration/include/mitkRegistrationWrapperMapperBase.h
@@ -46,7 +46,7 @@ public:
     virtual bool GetGeometryDescription(mitk::BaseRenderer *renderer, mitk::BaseGeometry::ConstPointer& gridDesc, unsigned int& gridFrequ) const = 0;
     virtual bool RendererGeometryIsOutdated(mitk::BaseRenderer *renderer, const itk::TimeStamp& time) const = 0;
 
-    /**Internal class to store all informations and helper needed by a mapper to provide the render data for a
+    /**Internal class to store all information and helper needed by a mapper to provide the render data for a
      certain renderer.*/
     class MITKMATCHPOINTREGISTRATION_EXPORT RegWrapperLocalStorage : public mitk::Mapper::BaseLocalStorage
     {

--- a/Modules/MatchPointRegistration/src/Helper/mitkMAPAlgorithmHelper.cpp
+++ b/Modules/MatchPointRegistration/src/Helper/mitkMAPAlgorithmHelper.cpp
@@ -304,7 +304,7 @@ namespace mitk
 
       /**@todo the duplication work around is needed due to a insufficuence
        in the AccessTwoImagesFixedDimensionByItk macro. The macro always cast
-       the passed image into non const (even if tha image was passed as const).
+       the passed image into non const (even if that image was passed as const).
        This behavior enforces the unnecessary use of an writeaccessor, which as a consequence
        will lead to redundant access exceptions as long as the algorithm exists;
        e.g. in the typical scenario with the MatchPoint Plugins*/

--- a/Modules/MatchPointRegistrationUI/Qmitk/QmitkMapperSettingsWidget.ui
+++ b/Modules/MatchPointRegistrationUI/Qmitk/QmitkMapperSettingsWidget.ui
@@ -143,7 +143,7 @@
          </sizepolicy>
         </property>
         <property name="toolTip">
-         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Value of pixels that cannot be registered because of an unsufficient field of view of the selected registration instance.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Value of pixels that cannot be registered because of an insufficient field of view of the selected registration instance.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
         </property>
         <property name="minimum">
          <number>-5000</number>

--- a/Modules/ModelFit/cmdapps/PixelDump.cpp
+++ b/Modules/ModelFit/cmdapps/PixelDump.cpp
@@ -88,7 +88,7 @@ void setupParser(mitkCommandLineParser& parser)
   // set general information about your MiniApp
   parser.setCategory("Generic Analysis Tools");
   parser.setTitle("Pixel Dumper");
-  parser.setDescription("MiniApp that allows to dump the pixel values of all passed files into a csv. The region of dumping can defined by a mask. All images (and mask) must have the same geometrie.");
+  parser.setDescription("MiniApp that allows to dump the pixel values of all passed files into a csv. The region of dumping can defined by a mask. All images (and mask) must have the same geometry.");
   parser.setContributor("DKFZ MIC");
   //! [create parser]
 

--- a/Modules/ModelFit/include/mitkModelFitFunctorBase.h
+++ b/Modules/ModelFit/include/mitkModelFitFunctorBase.h
@@ -91,7 +91,7 @@ namespace mitk
 
     ~ModelFitFunctorBase() override;
 
-    /**Internal Method called by Compute to get the final criterion values thar dove the fit.
+    /**Internal Method called by Compute to get the final criterion values that dove the fit.
      must be implemented be concrete functor classes.*/
     virtual OutputPixelArrayType GetCriteria(const ModelBase* model, const ParametersType& parameters,
         const SignalType& sample) const = 0;

--- a/Modules/Multilabel/autoload/DICOMSegIO/mitkDICOMSegmentationIO.cpp
+++ b/Modules/Multilabel/autoload/DICOMSegIO/mitkDICOMSegmentationIO.cpp
@@ -153,7 +153,7 @@ namespace mitk
     }
     catch (const std::exception &e)
     {
-      MITK_ERROR << "An error occurred while getting the dicom informations: " << e.what() << endl;
+      MITK_ERROR << "An error occurred while getting the dicom information: " << e.what() << endl;
       return;
     }
 
@@ -416,7 +416,7 @@ namespace mitk
           if (assumeOverlappingSegments)
           {
             // Add a new group because we have to expect every label to be overlapping
-            // the label content is directly transfered here.
+            // the label content is directly transferred here.
             groupID = labelSetImage->AddLayer(segmentImage);
           }
 
@@ -430,7 +430,7 @@ namespace mitk
           if (!assumeOverlappingSegments)
           {
             //if we know the labels are non overlapping we can put everything in one image
-            //the label content has to be transfered, as no new group was added.
+            //the label content has to be transferred, as no new group was added.
             mitk::TransferLabelContent(segmentImage, labelSetImage->GetGroupImage(groupID),
               labelSetImage->GetConstLabelsByValue(labelSetImage->GetLabelValuesByGroup(groupID)),
               mitk::LabelSetImage::UNLABELED_VALUE, mitk::LabelSetImage::UNLABELED_VALUE, false, {{segValue,newLabel->GetValue()}});

--- a/Modules/Multilabel/mitkLabelSetImageVtkMapper2D.h
+++ b/Modules/Multilabel/mitkLabelSetImageVtkMapper2D.h
@@ -158,7 +158,7 @@ namespace mitk
       */
     void TransformActor(mitk::BaseRenderer *renderer);
 
-    /** \brief Generates a plane according to the size of the resliced image in milimeters.
+    /** \brief Generates a plane according to the size of the resliced image in millimeters.
       *
       * In VTK a vtkPlaneSource is defined through three points. The origin and two
       * points defining the axes of the plane (see VTK documentation). The origin is

--- a/Modules/Multilabel/mitkMultiLabelEvents.h
+++ b/Modules/Multilabel/mitkMultiLabelEvents.h
@@ -59,7 +59,7 @@ namespace mitk
 
   /** Base event class for all events that are about a label in a MultiLabel class.
   *
-  * It has a member that indicates the label id the event is refering to.
+  * It has a member that indicates the label id the event is referring to.
   * Use the ANY_LABEL value if you want to define an rvent (e.g. for adding an observer)
   * that reacts to every label and not just to a special one.
   */
@@ -87,7 +87,7 @@ namespace mitk
 
   /** Event class that is used to indicated if a label is added in a MultiLabel class.
   *
-  * It has a member that indicates the label id the event is refering to.
+  * It has a member that indicates the label id the event is referring to.
   * Use the ANY_LABEL value if you want to define an rvent (e.g. for adding an observer)
   * that reacts to every label and not just to a special one.
   */
@@ -95,7 +95,7 @@ namespace mitk
 
   /** Event class that is used to indicated if a label is modified in a MultiLabel class.
   *
-  * It has a member that indicates the label id the event is refering to.
+  * It has a member that indicates the label id the event is referring to.
   * Use the ANY_LABEL value if you want to define an rvent (e.g. for adding an observer)
   * that reacts to every label and not just to a special one.
   */
@@ -103,7 +103,7 @@ namespace mitk
 
   /** Event class that is used to indicated if a label is removed in a MultiLabel class.
   *
-  * It has a member that indicates the label id the event is refering to.
+  * It has a member that indicates the label id the event is referring to.
   * Use the ANY_LABEL value if you want to define an rvent (e.g. for adding an observer)
   * that reacts to every label and not just to a special one.
   */
@@ -115,7 +115,7 @@ namespace mitk
   * the modification of the MultiLableImage instance is finished. So e.g. even if 4 labels are
   * changed by a merge operation, this event will only be sent once (compared to LabelRemoved
   * or LabelModified).
-  * It has a member that indicates the label ids the event is refering to.
+  * It has a member that indicates the label ids the event is referring to.
   */
   class MITKMULTILABEL_EXPORT LabelsChangedEvent : public itk::ModifiedEvent
   {
@@ -140,7 +140,7 @@ namespace mitk
 
   /** Base event class for all events that are about a group in a MultiLabel class.
   *
-  * It has a member that indicates the group id the event is refering to.
+  * It has a member that indicates the group id the event is referring to.
   * Use the ANY_GROUP value if you want to define an event (e.g. for adding an observer)
   * that reacts to every group and not just to a special one.
   */
@@ -169,7 +169,7 @@ namespace mitk
 
   /** Event class that is used to indicated if a group is added in a MultiLabel class.
   *
-  * It has a member that indicates the group id the event is refering to.
+  * It has a member that indicates the group id the event is referring to.
   * Use the ANY_GROUP value if you want to define an rvent (e.g. for adding an observer)
   * that reacts to every group and not just to a special one.
   */
@@ -177,7 +177,7 @@ namespace mitk
 
   /** Event class that is used to indicated if a group is modified in a MultiLabel class.
   *
-  * It has a member that indicates the group id the event is refering to.
+  * It has a member that indicates the group id the event is referring to.
   * Use the ANY_GROUP value if you want to define an rvent (e.g. for adding an observer)
   * that reacts to every group and not just to a special one.
   */
@@ -185,7 +185,7 @@ namespace mitk
 
   /** Event class that is used to indicated if a group is removed in a MultiLabel class.
   *
-  * It has a member that indicates the group id the event is refering to.
+  * It has a member that indicates the group id the event is referring to.
   * Use the ANY_GROUP value if you want to define an rvent (e.g. for adding an observer)
   * that reacts to every group and not just to a special one.
   */

--- a/Modules/Pharmacokinetics/include/mitkTwoCompartmentExchangeModel.h
+++ b/Modules/Pharmacokinetics/include/mitkTwoCompartmentExchangeModel.h
@@ -20,7 +20,7 @@ found in the LICENSE file.
 namespace mitk
 {
   /** @class TwoCompartmentExchangeModel
-   * @brief Implementation of the analystical model function of the Physiological Pharmacokinetic Brix model, using an Aterial Input Function
+   * @brief Implementation of the analytical model function of the Physiological Pharmacokinetic Brix model, using an Aterial Input Function
    * The Model calculates the Concentration-Time-Curve as a convolution of the Aterial Input funciton CA(t) and a tissue specific
    * residue function R(t). The Residue funktion consists of two parts: The Residue funktion Qp(t) of the Blood Plasma p and the residue funktion Qi(t) of the
    * interstitial volume I.

--- a/Modules/QtWidgets/include/QmitkAbstractMultiWidget.h
+++ b/Modules/QtWidgets/include/QmitkAbstractMultiWidget.h
@@ -124,7 +124,7 @@ public:
   virtual void InitializeViews(const mitk::TimeGeometry* geometry, bool resetCamera) = 0;
 
   /**
-  * @brief Define the reference geometry for interaction withing a render window.
+  * @brief Define the reference geometry for interaction within a render window.
   *
   * The concrete implementation is subclass-specific, no default implementation is provided here.
   *

--- a/Modules/QtWidgets/include/QmitkAbstractNodeSelectionWidget.h
+++ b/Modules/QtWidgets/include/QmitkAbstractNodeSelectionWidget.h
@@ -87,7 +87,7 @@ public Q_SLOTS:
   *   An outgoing selection can then at most contain the filtered nodes.
   *   If false, the incoming non-visible selection will be stored and later added to the outgoing selection,
   *   to include the original selection that could not be modified.
-  *   The part of the original selection, that is non-visible are the nodes, that do not fullfill the predicate.
+  *   The part of the original selection, that is non-visible are the nodes, that do not fulfill the predicate.
   *
   * @par selectOnlyVisibleNodes   The bool value to define the selection modus.
   */

--- a/Modules/QtWidgets/include/QmitkIOUtil.h
+++ b/Modules/QtWidgets/include/QmitkIOUtil.h
@@ -91,7 +91,7 @@ public:
    * user input is required (e.g. ambiguous mime-types or reader options).
    *
    * If the provided DataStorage is not nullptr, some files will be added to it automatically,
-   * dependeing on the IFileReader used.
+   * depending on the IFileReader used.
    *
    * @param paths
    * @param parent

--- a/Modules/QtWidgets/include/QmitkServiceListWidget.h
+++ b/Modules/QtWidgets/include/QmitkServiceListWidget.h
@@ -203,8 +203,8 @@ signals:
   /**
   *\brief Emitted when a Service matching the filter changes it's properties,
   *
-  * and the new properties make it fall trough the filter. This effectively means that
-  * the widget will not track the service anymore. Usually, the Service should still be useable though
+  * and the new properties make it fall through the filter. This effectively means that
+  * the widget will not track the service anymore. Usually, the Service should still be usable though
   */
   void ServiceModifiedEndMatch(us::ServiceReferenceU);
 
@@ -245,7 +245,7 @@ protected:
   void InitPrivate(const std::string &namingProperty, const std::string &filter);
 
   /**
-  * \brief Contains a list of currently active services and their entires in the list. This is wiped with every
+  * \brief Contains a list of currently active services and their entries in the list. This is wiped with every
   * ServiceRegistryEvent.
   */
   std::vector<ServiceListLink> m_ListContent;

--- a/Modules/QtWidgets/include/QmitkSynchronizedWidgetConnector.h
+++ b/Modules/QtWidgets/include/QmitkSynchronizedWidgetConnector.h
@@ -33,7 +33,7 @@ found in the LICENSE file.
 *        In order to desynchronize a node selection widget,
 *        'DisconnectWidget(const QmitkSynchronizedNodeSelectionWidget*)' has to be used.
 *        If a new node selection has been connected / synchronized,
-*        'SynchronizeWidget(QmitkSynchronizedNodeSelectionWidget*' can be used to initialy set
+*        'SynchronizeWidget(QmitkSynchronizedNodeSelectionWidget*' can be used to initially set
 *        the current selection and the current selection mode.
 *        For this, both values are stored in this class internally.
 */

--- a/Modules/QtWidgets/src/QmitkRenderWindow.cpp
+++ b/Modules/QtWidgets/src/QmitkRenderWindow.cpp
@@ -187,7 +187,7 @@ bool QmitkRenderWindow::event(QEvent* e)
       // left mouse button pressed. Hence, hovering over the 3-d render window will already result in rotating the
       // scene. In theory, this can be prevented by either disabling the WA_AcceptTouchEvents attribute for this widget
       // or by globally disabling the AA_SynthesizeMouseForUnhandledTouchEvents attribute for the whole application.
-      // Yet, here we are as a last resort, acknowleding touch events just to reject them.
+      // Yet, here we are as a last resort, acknowledging touch events just to reject them.
       return false;
 
     case QEvent::TouchCancel:

--- a/Modules/QtWidgetsExt/src/QmitkPointListView.cpp
+++ b/Modules/QtWidgetsExt/src/QmitkPointListView.cpp
@@ -154,7 +154,7 @@ void QmitkPointListView::OnListViewSelectionChanged(const QItemSelection &select
   // update selection of all points in pointset: select the one(s) that are selected in the view, deselect all others
   QModelIndexList selectedIndexes = selected.indexes();
 
-  // only call setSelectInfo on a point set with 'selected = true' if you deselcted the other entries
+  // only call setSelectInfo on a point set with 'selected = true' if you deselected the other entries
   int indexToSelect = -1;
 
   for (mitk::PointSet::PointsContainer::Iterator it =

--- a/Modules/RT/include/mitkDoseImageVtkMapper2D.h
+++ b/Modules/RT/include/mitkDoseImageVtkMapper2D.h
@@ -210,7 +210,7 @@ namespace mitk {
     */
     void TransformActor(mitk::BaseRenderer* renderer);
 
-    /** \brief Generates a plane according to the size of the resliced image in milimeters.
+    /** \brief Generates a plane according to the size of the resliced image in millimeters.
     *
     * In VTK a vtkPlaneSource is defined through three points. The origin and two
     * points defining the axes of the plane (see VTK documentation). The origin is

--- a/Modules/Segmentation/Algorithms/itkAdaptiveThresholdIterator.txx
+++ b/Modules/Segmentation/Algorithms/itkAdaptiveThresholdIterator.txx
@@ -274,7 +274,7 @@ namespace itk
   template <class TImage, class TFunction>
   void AdaptiveThresholdIterator<TImage, TFunction>::CheckSeedPointValue()
   {
-    // checks, if the value, that has been averaged over the N-27 neighborhood aorund the seedpoint is still inside
+    // checks, if the value, that has been averaged over the N-27 neighborhood around the seedpoint is still inside
     // the thresholds-ranges. if not, the actual value of the seedpoint (not averaged) is used
     if (m_SeedPointValue < m_MinTH || m_SeedPointValue > m_MaxTH)
     {

--- a/Modules/Segmentation/Interactions/mitkMonaiLabelTool.cpp
+++ b/Modules/Segmentation/Interactions/mitkMonaiLabelTool.cpp
@@ -446,7 +446,7 @@ void mitk::MonaiLabelTool::FetchOverallInfo(const std::string &hostName, const i
   }
   else
   {
-    Tool::ErrorMessage.Send(httplib::to_string(response.error()) + " error occured.");
+    Tool::ErrorMessage.Send(httplib::to_string(response.error()) + " error occurred.");
   }
 }
 
@@ -486,7 +486,7 @@ void mitk::MonaiLabelTool::PostInferRequest(const std::string &hostName,
   }
   items.push_back({"file", buffer_lf_img.str(), "post_from_mitk.nii.gz", "application/octet-stream"});
   httplib::SSLClient cli(hostName, port);
-  cli.set_read_timeout(60);                      // arbitary 1 minute time-out to avoid corner cases.
+  cli.set_read_timeout(60);                      // arbitrary 1 minute time-out to avoid corner cases.
   cli.enable_server_certificate_verification(false);
   if (auto response = cli.Post(postPath, items))
   {
@@ -526,8 +526,8 @@ void mitk::MonaiLabelTool::PostInferRequest(const std::string &hostName,
     else
     {
       auto err = response.error();
-      MITK_ERROR << "An HTTP POST error: " << httplib::to_string(err) << " occured.";
-      mitkThrow() << "An HTTP POST error: " << httplib::to_string(err) << " occured.";
+      MITK_ERROR << "An HTTP POST error: " << httplib::to_string(err) << " occurred.";
+      mitkThrow() << "An HTTP POST error: " << httplib::to_string(err) << " occurred.";
     }
   }
 }

--- a/Modules/Segmentation/Interactions/mitkSegTool2D.cpp
+++ b/Modules/Segmentation/Interactions/mitkSegTool2D.cpp
@@ -191,7 +191,7 @@ void mitk::SegTool2D::UpdateSurfaceInterpolation(const std::vector<SliceInformat
 
   //Remark: the ImageTimeSelector is just needed to extract a timestep/channel of
   //the image in order to get the image dimension (time dimension and channel dimension
-  //stripped away). Therfore it is OK to always use time step 0 and channel 0
+  //stripped away). Therefore it is OK to always use time step 0 and channel 0
   mitk::ImageTimeSelector::Pointer timeSelector = mitk::ImageTimeSelector::New();
   timeSelector->SetInput(workingImage);
   timeSelector->SetTimeNr(0);
@@ -219,17 +219,17 @@ void mitk::SegTool2D::UpdateSurfaceInterpolation(const std::vector<SliceInformat
 
       //Remark we cannot just errode the clone of sliceInfo.slice, because Erode currently only
       //works on pixel value 1. But we need to erode active label. Therefore we use TransferLabelContent
-      //as workarround.
-      //If MorphologicalOperations::Erode is supports user defined pixel values, the workarround
+      //as workaround.
+      //If MorphologicalOperations::Erode is supports user defined pixel values, the workaround
       //can be removed.
-      //Workarround starts
+      //Workaround starts
       mitk::Image::Pointer slice2 = Image::New();
       slice2->Initialize(sliceInfo.slice);
       AccessByItk(slice2, ClearBufferProcessing);
       LabelSetImage::LabelValueType erodeValue = 1;
       auto label = Label::New(erodeValue, "");
       TransferLabelContent(sliceInfo.slice, slice2, { label }, LabelSetImage::UNLABELED_VALUE, LabelSetImage::UNLABELED_VALUE, false, { {activeLabelValue, erodeValue} });
-      //Workarround ends
+      //Workaround ends
 
       mitk::MorphologicalOperations::Erode(slice2, 2, mitk::MorphologicalOperations::Ball);
       contourExtractor->SetInput(slice2);

--- a/Modules/Segmentation/Interactions/mitkSegTool2D.h
+++ b/Modules/Segmentation/Interactions/mitkSegTool2D.h
@@ -75,7 +75,7 @@ namespace mitk
      * @brief Updates the surface interpolations by extracting the contour form the given slice for all labels
      * that have a surface contour information stored for the given plane at the given timestep.
      * @param workingImage the segmentation image
-     * @param timeStep the time step for wich the surface interpolation information should be updated.
+     * @param timeStep the time step for which the surface interpolation information should be updated.
      * @param plane the plane in which the slice lies
      * @param detectIntersection if true the slice is eroded before contour extraction. If the slice is empty after the
      * erosion it is most likely an intersecting contour an will not be added to the SurfaceInterpolationController

--- a/Modules/Segmentation/Interactions/mitkSegWithPreviewTool.cpp
+++ b/Modules/Segmentation/Interactions/mitkSegWithPreviewTool.cpp
@@ -451,7 +451,7 @@ void mitk::SegWithPreviewTool::TransferImageAtTimeStep(const Image* sourceImage,
       auto resultSlice =
         SegTool2D::GetAffectedImageSliceAs2DImage(this->GetWorkingPlaneGeometry(), destinationImage, timeStep)->Clone();
       auto destLSImage = dynamic_cast<LabelSetImage *>(destinationImage);
-      //We need to transfer explictly to a copy of the current working image to ensure that labelMapping is done and things
+      //We need to transfer explicitly to a copy of the current working image to ensure that labelMapping is done and things
       //like merge style, overwrite style and locks are regarded.
       TransferLabelContentAtTimeStep(sourceSlice,
                                      resultSlice,

--- a/Modules/Segmentation/Interactions/mitkSegmentAnythingTool.cpp
+++ b/Modules/Segmentation/Interactions/mitkSegmentAnythingTool.cpp
@@ -252,7 +252,7 @@ void mitk::SegmentAnythingTool::ITKWindowing(const itk::Image<TPixel, VImageDime
 namespace
 {
   // Checks if the image has valid size across each dimension. The check is
-  // critical for 2D images since 2D image are not valid in Saggital and Coronal views.
+  // critical for 2D images since 2D image are not valid in Sagittal and Coronal views.
   bool IsImageAtTimeStepValid(const mitk::Image *inputAtTimeStep)
   {
     int total = 0;

--- a/Modules/Segmentation/Interactions/mitkSegmentAnythingTool.h
+++ b/Modules/Segmentation/Interactions/mitkSegmentAnythingTool.h
@@ -133,7 +133,7 @@ namespace mitk
     void ClearSeeds();
 
     /**
-     * @brief Overriden method from the tool manager to execute the segmentation
+     * @brief Overridden method from the tool manager to execute the segmentation
      * Implementation:
      * 1. Creates Hash for input image from current plane geometry.
      * 2. Transfers image pointer to python service along with the hash code.

--- a/Modules/SegmentationUI/Qmitk/QmitkMedSAMToolGUI.cpp
+++ b/Modules/SegmentationUI/Qmitk/QmitkMedSAMToolGUI.cpp
@@ -234,7 +234,7 @@ void QmitkMedSAMToolGUI::OnActivateBtnClicked()
   }
   catch (...)
   {
-    std::string errorMsg = "Unkown error occured while generation MedSAM segmentation.";
+    std::string errorMsg = "Unknown error occurred while generating MedSAM segmentation.";
     this->ShowErrorMessage(errorMsg);
     this->EnableAll(true);
     return;

--- a/Modules/SegmentationUI/Qmitk/QmitkMonaiLabelToolGUI.cpp
+++ b/Modules/SegmentationUI/Qmitk/QmitkMonaiLabelToolGUI.cpp
@@ -251,7 +251,7 @@ void QmitkMonaiLabelToolGUI::OnPreviewBtnClicked()
   }
   catch (...)
   {
-    std::string errorMsg = "Unkown error occured while generation MONAI Label segmentation.";
+    std::string errorMsg = "Unknown error occurred while generating MONAI Label segmentation.";
     this->ShowErrorMessage(errorMsg);
     m_Controls.previewButton->setEnabled(true);
     return;

--- a/Modules/SegmentationUI/Qmitk/QmitkSegmentAnythingToolGUI.cpp
+++ b/Modules/SegmentationUI/Qmitk/QmitkSegmentAnythingToolGUI.cpp
@@ -207,7 +207,7 @@ void QmitkSegmentAnythingToolGUI::OnActivateBtnClicked()
   }
   catch (...)
   {
-    std::string errorMsg = "Unkown error occured while generation Segment Anything segmentation.";
+    std::string errorMsg = "Unkown error occurred while generation Segment Anything segmentation.";
     this->ShowErrorMessage(errorMsg);
     this->EnableAll(true);
     return;

--- a/Modules/SegmentationUI/Qmitk/QmitkSetupVirtualEnvUtil.cpp
+++ b/Modules/SegmentationUI/Qmitk/QmitkSetupVirtualEnvUtil.cpp
@@ -141,7 +141,7 @@ bool QmitkSetupVirtualEnvUtil::IsVenvInstalled(const QString &pythonPath)
   const QString PYTHON_EXE = "python3";
 #endif
   pyProcess.start(pythonPath + QDir::separator() + PYTHON_EXE,
-                  QStringList() << "-m" << "venv", QProcess::ReadOnly); //insuffient args to provoke stderr out
+                  QStringList() << "-m" << "venv", QProcess::ReadOnly); //insufficient args to provoke stderr out
   if (pyProcess.waitForFinished())
   {
     auto venvCaptured = QString(QStringDecoder(QStringDecoder::Utf8)(pyProcess.readAllStandardError()));

--- a/Modules/SegmentationUI/test/QmitkMultiLabelTreeModelTest.cpp
+++ b/Modules/SegmentationUI/test/QmitkMultiLabelTreeModelTest.cpp
@@ -333,7 +333,7 @@ public:
   {
     QmitkMultiLabelTreeModel model(nullptr);
     model.SetSegmentation(m_Segmentation);
-    //remove label instance from label with multiple instances (middel)
+    //remove label instance from label with multiple instances (middle)
     m_Segmentation->RemoveLabel(5);
     CPPUNIT_ASSERT_EQUAL(3, model.rowCount(QModelIndex()));
     CPPUNIT_ASSERT(CheckModelRow(model, { 0 }, { QString("Group 1"), QVariant(), QVariant(), QVariant() }));

--- a/Modules/SurfaceInterpolation/mitkComputeContourSetNormalsFilter.h
+++ b/Modules/SurfaceInterpolation/mitkComputeContourSetNormalsFilter.h
@@ -31,7 +31,7 @@ found in the LICENSE file.
 namespace mitk
 {
   /**
-  \brief Filter to compute the normales for contours based on vtkPolygons
+  \brief Filter to compute the normals for contours based on vtkPolygons
 
 
 

--- a/Modules/SurfaceInterpolation/mitkCreateDistanceImageFromSurfaceFilter.cpp
+++ b/Modules/SurfaceInterpolation/mitkCreateDistanceImageFromSurfaceFilter.cpp
@@ -155,7 +155,7 @@ void mitk::CreateDistanceImageFromSurfaceFilter::PreprocessContourPoints()
     return;
   }
 
-  // First of all we have to extract the nomals and the surface points.
+  // First of all we have to extract the normals and the surface points.
   // Duplicated points can be eliminated
 
   vtkSmartPointer<vtkPolyData> polyData;
@@ -275,7 +275,7 @@ void mitk::CreateDistanceImageFromSurfaceFilter::CreateSolutionMatrixAndFunction
   {
     for (unsigned int j = 0; j < numberOfCenters; j++)
     {
-      // Calculate the RBF value. Currently using Phi(r) = r with r is the euclidian distance between two points
+      // Calculate the RBF value. Currently using Phi(r) = r with r is the euclidean distance between two points
       p1 = m_Centers.at(i);
       p2 = m_Centers.at(j);
       p1 = p1 - p2;
@@ -445,7 +445,7 @@ void mitk::CreateDistanceImageFromSurfaceFilter::GenerateOutputInformation()
 void mitk::CreateDistanceImageFromSurfaceFilter::PrintEquationSystem()
 {
   std::stringstream out;
-  out << "Nummber of rows: " << m_SolutionMatrix.rows() << " ****** Number of columns: " << m_SolutionMatrix.cols()
+  out << "Number of rows: " << m_SolutionMatrix.rows() << " ****** Number of columns: " << m_SolutionMatrix.cols()
       << endl;
   out << "[ ";
   for (int i = 0; i < m_SolutionMatrix.rows(); i++)

--- a/Modules/SurfaceInterpolation/mitkPlaneProposer.h
+++ b/Modules/SurfaceInterpolation/mitkPlaneProposer.h
@@ -37,7 +37,7 @@ namespace mitk
    * a plane to the provided point cloud or by using the centroid of three clusters
    *
    * If less than three clusters are provided, least squares is chosen automatically.
-   * If the centroid method is chosed either the three biggest clusters are chosen by
+   * If the centroid method is chosen either the three biggest clusters are chosen by
    * default. If the users sets PlaneProposer::SetUseDistances(true) the three clusters
    * with the biggerst mean distance of all points are chosen. The latter requires the
    * distances to be set as PointData scalar to the underlying VTK object.
@@ -49,7 +49,7 @@ namespace mitk
   {
   public:
     /**
-     * @brief Encapsulates the geometrical information needed to descripe a PlaneInfo
+     * @brief Encapsulates the geometrical information needed to describe a PlaneInfo
      *
      * normal = the normal of the plane
      * x,y = the axes of the PlaneInfo

--- a/Modules/SurfaceInterpolation/mitkReduceContourSetFilter.cpp
+++ b/Modules/SurfaceInterpolation/mitkReduceContourSetFilter.cpp
@@ -358,7 +358,7 @@ bool mitk::ReduceContourSetFilter::CheckForIntersection(
   /* vtkIdType numberOfIntersections, vtkIdType* intersectionPoints,*/ unsigned int currentInputIndex)
 {
   /*
-  If we check the current cell for intersections then we have to consider three possibilies:
+  If we check the current cell for intersections then we have to consider three possibilities:
   1. There is another cell among all the other input surfaces which intersects the current polygon:
   - That means we have to save the intersection points because these points should not be eliminated
   2. There current polygon exists just because of an intersection of another polygon with the current plane defined by
@@ -477,7 +477,7 @@ bool mitk::ReduceContourSetFilter::CheckForIntersection(
         return false;
       }
 
-      // Because we are considering the plane defined by the acual input polygon only one iteration is sufficient
+      // Because we are considering the plane defined by the actual input polygon only one iteration is sufficient
       // We do not need to consider each cell of the plane
       break;
     } // for (to traverse through all cells of actualInputPolyData)

--- a/Plugins/org.mitk.gui.qt.mxnmultiwidgeteditor/documentation/UserManual/QmitkMxNMultiWidgetEditor.dox
+++ b/Plugins/org.mitk.gui.qt.mxnmultiwidgeteditor/documentation/UserManual/QmitkMxNMultiWidgetEditor.dox
@@ -139,7 +139,7 @@
 	Displayed data is typically 3D data but each window view shows a 2D slice of the 3D volume. The direction in which the
 	3D volume is sliced is defined by the "view direction" (or "anatomical plane").
 	To define at which position in the view direction the 3D volume should be sliced, the slice selection slider can be used.
-	It can either be moved using the mouse or by using the appropriate mouse interaction (see above, e.g. mouse wheel scroling).
+	It can either be moved using the mouse or by using the appropriate mouse interaction (see above, e.g. mouse wheel scrolling).
 
 \subsubsection org_mitk_editors_mxnmultiwidget_View_Direction View direction
 	Each window view "is looking in" one of the three available view directions, namely "Axial", "Sagittal" or "Coronal".

--- a/Plugins/org.mitk.gui.qt.segmentation/src/QmitkSegmentAnythingPreferencePage.cpp
+++ b/Plugins/org.mitk.gui.qt.segmentation/src/QmitkSegmentAnythingPreferencePage.cpp
@@ -187,7 +187,7 @@ void QmitkSegmentAnythingPreferencePage::AutoParsePythonPaths()
     {
       subIt.next();
       QString envName = subIt.fileName();
-      if (!envName.startsWith('.')) // Filter out irrelevent hidden folders, if any.
+      if (!envName.startsWith('.')) // Filter out irrelevant hidden folders, if any.
       {
         m_Ui->sysPythonComboBox->addItem("(" + envName + "): " + subIt.filePath());
       }
@@ -242,7 +242,7 @@ void QmitkSegmentAnythingPreferencePage::OnInstallBtnClicked()
   if (!QmitkSetupVirtualEnvUtil::IsVenvInstalled(path))
   {
     this->WriteErrorMessage("venv module not found for the selected python to create a new virtual " 
-                            "environment. Please install venv or select another compatibile python");
+                            "environment. Please install venv or select another compatible python");
     return;
   }
   //check if python 3.12 and ask for confirmation

--- a/Plugins/org.mitk.gui.qt.segmentation/src/QmitkSegmentAnythingPreferencePage.h
+++ b/Plugins/org.mitk.gui.qt.segmentation/src/QmitkSegmentAnythingPreferencePage.h
@@ -66,7 +66,7 @@ private slots:
 
 protected:
   /**
-   * @brief Searches and parses paths of python virtual enviroments
+   * @brief Searches and parses paths of python virtual environments
    * from predefined lookout locations
    */
   void AutoParsePythonPaths();
@@ -81,7 +81,7 @@ protected:
 
   /**
    * @brief Adds GPU information to the gpu combo box.
-   * In case, there aren't any GPUs avaialble, the combo box will be
+   * In case, there aren't any GPUs available, the combo box will be
    * rendered editable.
    */
   void SetGPUInfo();


### PR DESCRIPTION
Found via `codespell -q 3 -S *.min.js -L alledges,anid,ba,childs,doubleclick,endianity,fiter,hsi,lod,nd,parms,pres,serie,sur,toi`