### PR TITLE
Update ITK to 5.4.2 to fix libtiff duplicate compiler error on newer MSVC versions

### DIFF
--- a/CMakeExternals/ITK.cmake
+++ b/CMakeExternals/ITK.cmake
@@ -45,7 +45,7 @@ if(NOT DEFINED ITK_DIR)
      LIST_SEPARATOR ${sep}
      UPDATE_COMMAND ""
      GIT_REPOSITORY https://github.com/InsightSoftwareConsortium/ITK.git
-     GIT_TAG 311b7060ef39e371f3cd209ec135284ff5fde735 # tag: v5.4.0
+     GIT_TAG 898def645183e6a2d3293058ade451ec416c4514 # tag: v5.4.2
      CMAKE_GENERATOR ${gen}
      CMAKE_GENERATOR_PLATFORM ${gen_platform}
      CMAKE_ARGS


### PR DESCRIPTION
ITK 5.4.0 suffers from a compiler error concerning a duplicated `__ucrt_int_to_float` symbol with current MSVC compiler versions.
The most recent version ITK 5.4.2 includes a fix for this via [this](https://github.com/InsightSoftwareConsortium/ITK/pull/4958) PR.

I'd suggest to update ITK so that MITK compiles with current MSVC versions. 