### PR TITLE
[BUGFIX]Plugin:berryReferenceCounter:ineffective RemoveRef.

### DIFF
--- a/Plugins/org.blueberry.ui.qt/src/internal/berryReferenceCounter.h
+++ b/Plugins/org.blueberry.ui.qt/src/internal/berryReferenceCounter.h
@@ -185,12 +185,12 @@ public:
    */
   int RemoveRef(I id)
   {
-    RefRec rec = mapIdToRec[id];
-    if (rec.GetRef() == 0)
+    typename QHash<I, RefRec>::iterator rec = mapIdToRec.find(id);
+    if (rec == mapIdToRec.end())
     {
       return 0;
     }
-    int newCount = rec.RemoveRef();
+    int newCount = rec.value().RemoveRef();
     if (newCount <= 0)
     {
       mapIdToRec.remove(id);


### PR DESCRIPTION
RemoveRef method decreases ref count on a duplicate of RefRec object which doesn't take any effect.
Signed-off-by: Guangye Tian <guangye_tian@sdu.edu.cn>
