### PR TITLE
fix: crash on removing a DataNode from the DataManager due to missing…

### DIFF
--- a/Modules/QtWidgets/src/QmitkDataStorageSimpleTreeModel.cpp
+++ b/Modules/QtWidgets/src/QmitkDataStorageSimpleTreeModel.cpp
@@ -108,6 +108,7 @@ void QmitkDataStorageSimpleTreeModel::NodeRemoved(const mitk::DataNode *node)
   std::vector<TreeItem *> children = treeItem->GetChildren();
   m_TreeItems.remove(treeItem);
   delete treeItem; //delete in tree
+  this->endRemoveRows();
 
   if (!children.empty())
   {
@@ -279,6 +280,9 @@ Qt::ItemFlags QmitkDataStorageSimpleTreeModel::flags(const QModelIndex &index) c
       return Qt::NoItemFlags;
 
     const auto dataNode = treeItem->GetDataNode();
+    if (dataNode == nullptr)
+      return Qt::NoItemFlags;
+
     if (m_NodePredicate.IsNull() || m_NodePredicate->CheckNode(dataNode))
     {
       return Qt::ItemIsEnabled | Qt::ItemIsSelectable | Qt::ItemIsEditable;


### PR DESCRIPTION
fix: crash on removing a DataNode from the DataManager due to missing endRemoveRows in `QmitkDataStorageSimpleTreeModel::NodeRemoved` and `nullptr` in `QmitkDataStorageSimpleTreeModel::flags` causing the `mitk::NodePredicateAnd::CheckNode` to `throw std::invalid_argument("NodePredicateAnd: invalid node");`

Closes #316