### PR TITLE
Remove unused forward declaration of itk::MutexLockHolder

### DIFF
--- a/Modules/Core/include/mitkImage.h
+++ b/Modules/Core/include/mitkImage.h
@@ -30,12 +30,6 @@ found in the LICENSE file.
 
 class vtkImageData;
 
-namespace itk
-{
-  template <class T>
-  class MutexLockHolder;
-}
-
 namespace mitk
 {
   class SubImageSelector;


### PR DESCRIPTION
Removes the unused forward declaration of `itk::MutexLockHolder` from `Modules/Core/include/mitkImage.h`. Fixes #325.

Cleanup only — no behavior change, and no diagnostic before or after.

<details>
<summary>Why it is safe to delete</summary>

`git grep MutexLockHolder` over all tracked files on `develop` returns exactly one hit, the declaration itself:

```
Modules/Core/include/mitkImage.h:36:  class MutexLockHolder;
```

After this change the search returns nothing. There is no use site, so no translation unit can lose a needed declaration.

For context on the referenced class, though it does not affect the reasoning above: MITK pins ITK `v5.4.6-patched` (`CMakeExternals/ITK.cmake`), where `itk::MutexLockHolder` still exists but is confined to `Modules/Compatibility/Deprecated/`. ITK removed it in `6.0a01` (ITK commit `91251de`). An unused forward declaration of a never-defined class template is legal C++ either way, so this is not a latent build break — it is a stale reference in a widely included public header.

</details>

<details>
<summary>Verification</summary>

- Exhaustive reference search across all tracked file types, before and after, as above.
- `clang-format --dry-run -Werror` on `mitkImage.h`: 25 violations before, 25 after — identical. All are pre-existing and elsewhere in the file; none were introduced, and per the contributing guidelines I did not reformat them here.
- Not compiled: MITK's superbuild is not configured on this machine. For an unreferenced declaration the exhaustive reference search is the conclusive check, and CI will confirm.

</details>

<!--
provenance: found while enumerating downstream `namespace itk { ... }` forward declarations
             for InsightSoftwareConsortium/ITK#6786 (build-configurable ITK namespace design).
             Incidental to that work and independent of its outcome.
verified: git grep on develop -> 1 occurrence (the decl), 0 after removal
verified: ITK v5.4.6 has itkMutexLockHolder.h in Modules/Compatibility/Deprecated/; v6.0a01 has 0 such files
verified: clang-format violation count unchanged (25 -> 25)
-->
